### PR TITLE
StrategoAppl: Fix off-by-one bounds check

### DIFF
--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoAppl.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoAppl.java
@@ -51,7 +51,7 @@ public class StrategoAppl extends StrategoTerm implements IStrategoAppl {
     }
 
     public IStrategoTerm getSubterm(int index) {
-        if (index < 0 || index > kids.length)
+        if (index < 0 || index >= kids.length)
             throw new IndexOutOfBoundsException("Index out of bounds: " + index);
         return kids[index];
     }


### PR DESCRIPTION
I encountered this bug when trying to update paplj to the new dynsem implementation. It called `getSubterm` with `0` as its argument, but it threw an ArrayIndexOutOfBoundsException. So it got to line 56 (i.e. `return kids[index]`) despite being out of bounds.

I searched for other off-by-one bound checks but could not find one.