### PR TITLE
increase length of pooled strings to 200

### DIFF
--- a/org.spoofax.terms/src/org/spoofax/terms/TermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/TermFactory.java
@@ -19,7 +19,7 @@ import org.spoofax.interpreter.terms.IStrategoTuple;
 import org.spoofax.interpreter.terms.ITermFactory;
 
 public class TermFactory extends AbstractTermFactory implements ITermFactory {
-    private static final int MAX_POOLED_STRING_LENGTH = 100;
+    private static final int MAX_POOLED_STRING_LENGTH = 200;
     private static final Set<String> usedStrings = Collections.newSetFromMap(new WeakHashMap<String, Boolean>());
 
     private IStrategoConstructor placeholderConstructor;


### PR DESCRIPTION
see http://yellowgrass.org/issue/SpoofaxWithCore/184

Increasing `MAX_POOLED_STRING_LENGTH` to `200` in `org.spoofax.terms.TermFactory` fixed the issue.