### PR TITLE
Remove term sharing and storage type

### DIFF
--- a/org.spoofax.terms.typesmart/src/org/spoofax/terms/typesmart/TypesmartSortAttachment.java
+++ b/org.spoofax.terms.typesmart/src/org/spoofax/terms/typesmart/TypesmartSortAttachment.java
@@ -44,7 +44,7 @@ public class TypesmartSortAttachment extends AbstractTermAttachment {
         private SortType[] ar;
 
         protected StrategoSortTypeArray(SortType[] ar) {
-            super(null, IStrategoTerm.MUTABLE);
+            super(null);
             this.ar = ar;
         }
 
@@ -53,7 +53,7 @@ public class TypesmartSortAttachment extends AbstractTermAttachment {
         }
 
         @Override public IStrategoTerm getSubterm(int index) {
-            return new StrategoString(ar[index].toString(), null, IStrategoTerm.MUTABLE);
+            return new StrategoString(ar[index].toString(), null);
         }
 
         @Override public IStrategoTerm[] getAllSubterms() {
@@ -79,7 +79,7 @@ public class TypesmartSortAttachment extends AbstractTermAttachment {
             return new ArrayIterator<>(getAllSubterms());
         }
 
-        @Override protected boolean doSlowMatch(IStrategoTerm second, int commonStorageType) {
+        @Override protected boolean doSlowMatch(IStrategoTerm second) {
             if(second instanceof StrategoSortTypeArray)
                 return Arrays.equals(ar, ((StrategoSortTypeArray) second).ar);
             return false;

--- a/org.spoofax.terms.typesmart/src/org/spoofax/terms/typesmart/TypesmartTermFactory.java
+++ b/org.spoofax.terms.typesmart/src/org/spoofax/terms/typesmart/TypesmartTermFactory.java
@@ -34,9 +34,7 @@ public class TypesmartTermFactory extends AbstractWrappedTermFactory {
     private final TypesmartContext context;
 
     public TypesmartTermFactory(ITermFactory baseFactory, ILogger logger, TypesmartContext context) {
-        super(baseFactory.getDefaultStorageType(), baseFactory);
-        assert baseFactory
-            .getDefaultStorageType() == IStrategoTerm.MUTABLE : "Typesmart factory needs to have a factory with MUTABLE terms";
+        super(baseFactory);
         this.baseFactory = baseFactory;
         this.logger = logger;
         this.context = context;
@@ -180,16 +178,6 @@ public class TypesmartTermFactory extends AbstractWrappedTermFactory {
             TypesmartSortAttachment.put(result, attach);
 
         return result;
-    }
-
-    public ITermFactory getFactoryWithStorageType(int storageType) {
-        if(storageType != IStrategoTerm.MUTABLE)
-            throw new RuntimeException("Typesmart factory cannot work with NON-MUTABLE terms");
-
-        if(storageType == getDefaultStorageType())
-            return this;
-
-        return new TypesmartTermFactory(baseFactory.getFactoryWithStorageType(storageType), logger, context);
     }
 
     /**

--- a/org.spoofax.terms/src/org/spoofax/interpreter/terms/IStrategoTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/interpreter/terms/IStrategoTerm.java
@@ -24,11 +24,6 @@ public interface IStrategoTerm extends ISimpleTerm, Serializable, Iterable<IStra
     public static final int BLOB = 9;
     public static final int PLACEHOLDER = 10;
     
-    public static final int MUTABLE = 0;
-    public static final int IMMUTABLE = 1;
-    public static final int SHARABLE = 2;
-    public static final int MAXIMALLY_SHARED = 3;
-    
     public static final int INFINITE = Integer.MAX_VALUE;
 
     public int getSubtermCount();
@@ -36,25 +31,6 @@ public interface IStrategoTerm extends ISimpleTerm, Serializable, Iterable<IStra
     public IStrategoTerm[] getAllSubterms();
     
     public int getTermType();
-    
-    /**
-     * Indicates the assumptions that can be made about how this term is stored.
-     * 
-     * One of {@value #MUTABLE}, {@value #IMMUTABLE}, {@value #SHARABLE} and
-     * {@value #MAXIMALLY_SHARED}. For each a specific contract exists; 
-     * only {@value #MUTABLE} poses no restrictions on the implementation.
-     * 
-     * All non-{@value #MUTABLE} terms are expected to have an O(1)
-     * {@link #hashCode()} implementation.
-     * 
-     * A general contract is that the storage type of a term must always 
-     * be smaller than or equal to the storage types of its subterms.
-     * 
-     * Finally, when multiple term factories are used together,
-     * they should use the same hash codes for equal terms: 
-     * the TermFactory classes should be used as a reference.
-     */
-    public int getStorageType();
     
     public IStrategoList getAnnotations();
     

--- a/org.spoofax.terms/src/org/spoofax/interpreter/terms/IStrategoTermBuilder.java
+++ b/org.spoofax.terms/src/org/spoofax/interpreter/terms/IStrategoTermBuilder.java
@@ -11,7 +11,6 @@ import java.util.Collection;
 
 
 public interface IStrategoTermBuilder {
-    
     public IStrategoConstructor makeConstructor(String string, int arity);
     
     // @Deprecated public IStrategoAppl makeAppl(IStrategoConstructor ctr, IStrategoList kids);
@@ -38,27 +37,11 @@ public interface IStrategoTermBuilder {
     
     public IStrategoString tryMakeUniqueString(String name);
     
-    public int getDefaultStorageType();
-    
     public IStrategoTerm copyAttachments(IStrategoTerm from, IStrategoTerm to);
-    
-    /**
-     * Sets the default storage type for terms, returning a (usually new) factory
-     * that guarantees it will never create terms with a higher storage
-     * type value than the given value.
-     * 
-     * Implementors should note that even strings and empty lists
-     * follow this contract, allowing users to create mutable
-     * terms and use term attachments.
-     * 
-     * @throws UnsupportedOperationException if the given storage type is not supported.
-     */
-    public IStrategoTermBuilder getFactoryWithStorageType(int storageType);
 
     default IStrategoAppl makeAppl(String cons, IStrategoTerm... children) {
         return makeAppl(makeConstructor(cons, children.length), children, null);
     }
-    
 }
 
 

--- a/org.spoofax.terms/src/org/spoofax/interpreter/terms/ITermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/interpreter/terms/ITermFactory.java
@@ -35,6 +35,4 @@ public interface ITermFactory extends IStrategoTermBuilder {
     public IStrategoTerm replaceTerm(IStrategoTerm term, IStrategoTerm old);
     
     public IStrategoTuple replaceTuple(IStrategoTerm[] kids, IStrategoTuple old);
-    
-    public ITermFactory getFactoryWithStorageType(int storageType);
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/AbstractSimpleTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/AbstractSimpleTerm.java
@@ -1,77 +1,73 @@
 package org.spoofax.terms;
 
 import org.spoofax.interpreter.terms.ISimpleTerm;
-import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.terms.attachments.ITermAttachment;
 import org.spoofax.terms.attachments.TermAttachmentType;
 
 public abstract class AbstractSimpleTerm implements ISimpleTerm, Cloneable {
     private static final long serialVersionUID = 1L;
-    
+
     private ITermAttachment attachment;
-    
+
     @SuppressWarnings("unchecked")
-	public<T extends ITermAttachment> T getAttachment(TermAttachmentType<T> type) {
-    	if (type == null)
-    		return (T) this.attachment;
-    	for (ITermAttachment a = this.attachment; a != null; a = a.getNext()) {
-    		if (a.getAttachmentType() == type)
-    			return (T) a;
-    	}
-		return null;
+    public <T extends ITermAttachment> T getAttachment(TermAttachmentType<T> type) {
+        if(type == null)
+            return (T) this.attachment;
+        for(ITermAttachment a = this.attachment; a != null; a = a.getNext()) {
+            if(a.getAttachmentType() == type)
+                return (T) a;
+        }
+        return null;
     }
-    
+
     public void putAttachment(ITermAttachment attachment) {
-    	if (attachment == null) return;
-    	assert !(this instanceof IStrategoTerm)
-    		|| ((IStrategoTerm) this).getStorageType() == IStrategoTerm.MUTABLE
-    		: "Attachments only supported for mutable, non-shared terms; failed for " + this;
-//    	assert attachment.getNext() == null;
-    	if (this.attachment == null) {
-    		this.attachment = attachment;
-    	} else {
-    		TermAttachmentType<?> newType = attachment.getAttachmentType();
-    		if (this.attachment.getAttachmentType() == newType) {
-    			attachment.setNext(this.attachment.getNext());
-    			this.attachment = attachment;
-    		} else {
-    			ITermAttachment previous = this.attachment;
-    			for (ITermAttachment a = previous.getNext(); a != null; a = a.getNext()) {
-	        		if (a.getAttachmentType() == newType) {
-	        			attachment.setNext(a.getNext());
-	        			previous.setNext(attachment);
-	        			break;
-	        		}
-	        		previous = a;
-	        	}
-    			previous.setNext(attachment);
-    		}
-    	}
+        if(attachment == null)
+            return;
+        if(this.attachment == null) {
+            this.attachment = attachment;
+        } else {
+            TermAttachmentType<?> newType = attachment.getAttachmentType();
+            if(this.attachment.getAttachmentType() == newType) {
+                attachment.setNext(this.attachment.getNext());
+                this.attachment = attachment;
+            } else {
+                ITermAttachment previous = this.attachment;
+                for(ITermAttachment a = previous.getNext(); a != null; a = a.getNext()) {
+                    if(a.getAttachmentType() == newType) {
+                        attachment.setNext(a.getNext());
+                        previous.setNext(attachment);
+                        break;
+                    }
+                    previous = a;
+                }
+                previous.setNext(attachment);
+            }
+        }
     }
-    
+
     public ITermAttachment removeAttachment(TermAttachmentType<?> type) {
-		if (attachment != null) {
-			if (attachment.getAttachmentType() == type) {
-				ITermAttachment old = attachment;
-				attachment = attachment.getNext();
-				old.setNext(null);
-				return old;
-			} else {
-				ITermAttachment previous = this.attachment;
-				for (ITermAttachment a = attachment.getNext(); a != null; a = a.getNext()) {
-					if (a.getAttachmentType() == type) {
-						previous.setNext(a.getNext());
-						a.setNext(null);
-						return a;
-					}
-					previous = a;
-				}
-			}
-		}
-		return null;
+        if(attachment != null) {
+            if(attachment.getAttachmentType() == type) {
+                ITermAttachment old = attachment;
+                attachment = attachment.getNext();
+                old.setNext(null);
+                return old;
+            } else {
+                ITermAttachment previous = this.attachment;
+                for(ITermAttachment a = attachment.getNext(); a != null; a = a.getNext()) {
+                    if(a.getAttachmentType() == type) {
+                        previous.setNext(a.getNext());
+                        a.setNext(null);
+                        return a;
+                    }
+                    previous = a;
+                }
+            }
+        }
+        return null;
     }
-    
+
     protected void clearAttachments() {
-    	attachment = null;
+        attachment = null;
     }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/AbstractTermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/AbstractTermFactory.java
@@ -1,55 +1,30 @@
 package org.spoofax.terms;
 
-import static java.lang.Math.min;
-import static org.spoofax.interpreter.terms.IStrategoTerm.MAXIMALLY_SHARED;
-import static org.spoofax.interpreter.terms.IStrategoTerm.MUTABLE;
+import org.spoofax.interpreter.terms.*;
+import org.spoofax.terms.attachments.ITermAttachment;
 
 import java.util.Collection;
 import java.util.HashMap;
 
-import org.spoofax.interpreter.terms.IStrategoAppl;
-import org.spoofax.interpreter.terms.IStrategoConstructor;
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.IStrategoTuple;
-import org.spoofax.interpreter.terms.ITermFactory;
-import org.spoofax.terms.attachments.ITermAttachment;
-
 public abstract class AbstractTermFactory implements ITermFactory {
 
-	@Deprecated
-	public static final IStrategoList EMPTY_LIST = new StrategoList(null, null, null, IStrategoTerm.MAXIMALLY_SHARED);
+    @Deprecated
+    public static final IStrategoList EMPTY_LIST = new StrategoList(null, null, null);
 
     public static final IStrategoTerm[] EMPTY = new IStrategoTerm[0];
-    
-    private final StringTermReader reader = new StringTermReader(this);
-
     private static final HashMap<StrategoConstructor, StrategoConstructor> asyncCtorCache =
         new HashMap<StrategoConstructor, StrategoConstructor>();
-    
-    protected int defaultStorageType;
-    
-    public AbstractTermFactory(int defaultStorageType) {
-		this.defaultStorageType = defaultStorageType;
-	}
-    
-    public final int getDefaultStorageType() {
-		return defaultStorageType;
-	}
-    
-    protected final boolean isTermSharingAllowed() {
-    	return defaultStorageType != MUTABLE;
-    }
-    
+    private final StringTermReader reader = new StringTermReader(this);
+
     static StrategoConstructor createCachedConstructor(String name, int arity) {
         StrategoConstructor result = new StrategoConstructor(name, arity);
-        synchronized (TermFactory.class) {
-	        StrategoConstructor cached = asyncCtorCache.get(result);
-	        if (cached == null) {
-	            asyncCtorCache.put(result, result);
-	        } else {
-	            result = cached;
-	        }
+        synchronized(TermFactory.class) {
+            StrategoConstructor cached = asyncCtorCache.get(result);
+            if(cached == null) {
+                asyncCtorCache.put(result, result);
+            } else {
+                result = cached;
+            }
         }
         return result;
     }
@@ -58,38 +33,35 @@ public abstract class AbstractTermFactory implements ITermFactory {
         return createCachedConstructor(name, arity);
     }
 
-    public abstract IStrategoAppl makeAppl(IStrategoConstructor constructor,
-			IStrategoTerm[] kids, IStrategoList annotations);
+    public abstract IStrategoAppl makeAppl(IStrategoConstructor constructor, IStrategoTerm[] kids,
+        IStrategoList annotations);
 
-    public abstract IStrategoTuple makeTuple(
-			IStrategoTerm[] kids, IStrategoList annotations);
+    public abstract IStrategoTuple makeTuple(IStrategoTerm[] kids, IStrategoList annotations);
 
-    public abstract IStrategoList makeList(
-			IStrategoTerm[] kids, IStrategoList annotations);
+    public abstract IStrategoList makeList(IStrategoTerm[] kids, IStrategoList annotations);
 
-    public IStrategoAppl replaceAppl(IStrategoConstructor constructor, IStrategoTerm[] kids,
-            IStrategoAppl old) {
+    public IStrategoAppl replaceAppl(IStrategoConstructor constructor, IStrategoTerm[] kids, IStrategoAppl old) {
         return makeAppl(constructor, kids, old.getAnnotations());
     }
 
-	public IStrategoTuple replaceTuple(IStrategoTerm[] kids, IStrategoTuple old) {
+    public IStrategoTuple replaceTuple(IStrategoTerm[] kids, IStrategoTuple old) {
         return makeTuple(kids, old.getAnnotations());
     }
-    
+
     public IStrategoList replaceList(IStrategoTerm[] kids, IStrategoList old) {
         return makeList(kids, old.getAnnotations());
     }
-    
-    public IStrategoList replaceListCons(IStrategoTerm head, IStrategoList tail, IStrategoTerm oldHead, IStrategoList oldTail) {
+
+    public IStrategoList replaceListCons(IStrategoTerm head, IStrategoList tail, IStrategoTerm oldHead,
+        IStrategoList oldTail) {
         return makeListCons(head, tail);
     }
-    
+
     public IStrategoTerm replaceTerm(IStrategoTerm term, IStrategoTerm old) {
-    	return term;
+        return term;
     }
 
-    public final IStrategoAppl makeAppl(IStrategoConstructor ctr, IStrategoList kids,
-            IStrategoList annotations) {
+    public final IStrategoAppl makeAppl(IStrategoConstructor ctr, IStrategoList kids, IStrategoList annotations) {
         return makeAppl(ctr, kids.getAllSubterms(), annotations);
     }
 
@@ -114,64 +86,30 @@ public abstract class AbstractTermFactory implements ITermFactory {
     }
 
     public final IStrategoList makeListCons(IStrategoTerm head, IStrategoList tail) {
-        return makeListCons (head, tail, null);
+        return makeListCons(head, tail, null);
     }
 
     public abstract IStrategoList makeListCons(IStrategoTerm head, IStrategoList tail, IStrategoList annos);
 
-	public final IStrategoTuple makeTuple(IStrategoTerm... terms) {
+    public final IStrategoTuple makeTuple(IStrategoTerm... terms) {
         return makeTuple(terms, null);
     }
-    
+
     public IStrategoTerm parseFromString(String text) throws ParseError {
-    	return reader.parseFromString(text);
-    }
-    
-    protected static int getStorageType(IStrategoTerm term) {
-    	return term == null ? MAXIMALLY_SHARED : term.getStorageType();
-    }
-    
-    protected static int getStorageType(IStrategoTerm term1, IStrategoTerm term2) {
-    	int result = term1.getStorageType();
-    	if (result == 0) return 0;
-    	return min(result, term2.getStorageType());
-    }
-    
-    protected int getStorageType(IStrategoTerm[] terms) {
-    	int result = defaultStorageType;
-    	for (IStrategoTerm term : terms) {
-    		int type = term.getStorageType();
-    		if (type < result) { 
-        		if (type == 0) return 0;
-    			result = type;
-    		}
-    	}
-    	return result;
-    }
-    
-    public IStrategoTerm copyAttachments(IStrategoTerm from, IStrategoTerm to) {
-    	if (to.getStorageType() != MUTABLE)
-    		throw new IllegalArgumentException("Target term is not mutable and does not support attachments");
-    	ITermAttachment attach = from.getAttachment(null);
-    	while (attach != null) {
-    		try {
-				to.putAttachment(attach.clone());
-			} catch (CloneNotSupportedException e) {
-				throw new IllegalArgumentException("Copying attachments of this type is not supported: " + attach.getAttachmentType(), e);
-			}
-    		attach = attach.getNext();
-    	}
-    	return to;
+        return reader.parseFromString(text);
     }
 
-	/**
-	 * Performs a sanity check on a factory,
-	 * testing if it produces terms with a storage type
-	 * smaller or equal than the given value.
-	 */
-    public static boolean checkStorageType(ITermFactory factory, int storageType) {
-		return factory.getDefaultStorageType() <= storageType
-				&& factory.makeList(EMPTY).getStorageType() <= storageType
-				&& factory.makeString("Sanity").getStorageType() <= storageType;
-	}
+    public IStrategoTerm copyAttachments(IStrategoTerm from, IStrategoTerm to) {
+        ITermAttachment attach = from.getAttachment(null);
+        while(attach != null) {
+            try {
+                to.putAttachment(attach.clone());
+            } catch(CloneNotSupportedException e) {
+                throw new IllegalArgumentException(
+                    "Copying attachments of this type is not supported: " + attach.getAttachmentType(), e);
+            }
+            attach = attach.getNext();
+        }
+        return to;
+    }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/LazyTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/LazyTerm.java
@@ -84,10 +84,6 @@ public abstract class LazyTerm implements IStrategoAppl, IStrategoInt, IStratego
 		return getWrapped().getAnnotations();
 	}
 
-	public int getStorageType() {
-		return MUTABLE; // let's not spread these guys // Math.min(SHARABLE, getWrapped().getStorageType());
-	}
-
 	public boolean match(IStrategoTerm second) {
 		return getWrapped().match(second);
 	}

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoAnnotation.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoAnnotation.java
@@ -1,99 +1,88 @@
 package org.spoofax.terms;
 
-import java.io.IOException;
-
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
 import org.spoofax.interpreter.terms.ITermPrinter;
 
+import java.io.IOException;
+
 /**
  * Wraps any term with annotations.
- * 
+ * <p>
  * Uses its own set of attachments, rather than
  * the attachments of the wrapped term.
- * 
- * 
- * @see ITermFactory#annotateTerm(IStrategoTerm, IStrategoList)
- *          Should generally be used to efficiently annotate a term.
- * 
+ *
  * @author Lennart Kats <lennart add lclnet.nl>
+ * @see ITermFactory#annotateTerm(IStrategoTerm, IStrategoList)
+ * Should generally be used to efficiently annotate a term.
  */
 public class StrategoAnnotation extends StrategoWrapped {
-	
-	private static final long serialVersionUID = 2918341202178665547L;
 
-	private final ITermFactory factory;
-	
-	public StrategoAnnotation(ITermFactory factory, IStrategoTerm term, IStrategoList annotations) {
-		super(term, annotations);
-		
-		if (!term.getAnnotations().isEmpty())
-			throw new IllegalArgumentException("Annotated term cannot already have annotations");
-		
-		this.factory = factory;
-		
-		//if (storageType != MUTABLE)
-		//	initImmutableHashCode();
-	}
-	
-	@Override
-	protected boolean doSlowMatch(IStrategoTerm second, int commonStorageType) {
-		IStrategoTerm wrapped = getWrapped();
-		IStrategoList annotations = getAnnotations();
-		IStrategoList secondAnnotations = second.getAnnotations();
-		
-		if (annotations == secondAnnotations) {
-        	// Do nothing
-        } else if (annotations.match(secondAnnotations)) {
-        	if (commonStorageType == SHARABLE) internalSetAnnotations(secondAnnotations);
-        } else {
-        	return false;
+    private static final long serialVersionUID = 2918341202178665547L;
+
+    private final ITermFactory factory;
+
+    public StrategoAnnotation(ITermFactory factory, IStrategoTerm term, IStrategoList annotations) {
+        super(term, annotations);
+
+        if(!term.getAnnotations().isEmpty())
+            throw new IllegalArgumentException("Annotated term cannot already have annotations");
+
+        this.factory = factory;
+    }
+
+    @Override
+    protected boolean doSlowMatch(IStrategoTerm second) {
+        IStrategoTerm wrapped = getWrapped();
+        IStrategoList annotations = getAnnotations();
+        IStrategoList secondAnnotations = second.getAnnotations();
+
+        if(annotations != secondAnnotations && !annotations.match(secondAnnotations)) {
+            return false;
         }
-		
-		if (annotations.isEmpty()) {
-			return wrapped.match(second);
-		} else {
-			second = factory.annotateTerm(second, TermFactory.EMPTY_LIST);
-			return wrapped.match(second);
-		}
-	}
 
-	@Override
-	protected int hashFunction() {
-		assert getWrapped().getAnnotations().isEmpty() : "Constructor contract broken";
-		return getWrapped().hashCode();
-	}
+        if(!annotations.isEmpty()) {
+            second = factory.annotateTerm(second, TermFactory.EMPTY_LIST);
+        }
+        return wrapped.match(second);
+    }
 
-	@Override
-	public String toString() {
-		StringBuilder result = new StringBuilder();
-		try {
-			getWrapped().writeAsString(result, Integer.MAX_VALUE);
-			appendAnnotations(result, Integer.MAX_VALUE);
-		} catch (IOException e) {
-			throw new RuntimeException(e); // shan't happen
-		}
-		return result.toString();
-	}
-	
-	@Override
-	public void writeAsString(Appendable output, int maxDepth) throws IOException {
-		getWrapped().writeAsString(output, maxDepth);
-		appendAnnotations(output, maxDepth);
-	}
-	
-	@Override
-	@Deprecated
-	public void prettyPrint(ITermPrinter pp) {
-		getWrapped().prettyPrint(pp);
-		printAnnotations(pp);
-	}
+    @Override
+    protected int hashFunction() {
+        assert getWrapped().getAnnotations().isEmpty() : "Constructor contract broken";
+        return getWrapped().hashCode();
+    }
 
-	@Override
-	@Deprecated
-	public IStrategoList prepend(IStrategoTerm prefix) {
-		throw new UnsupportedOperationException();
-	}
-	
+    @Override
+    public String toString() {
+        StringBuilder result = new StringBuilder();
+        try {
+            getWrapped().writeAsString(result, Integer.MAX_VALUE);
+            appendAnnotations(result, Integer.MAX_VALUE);
+        } catch(IOException e) {
+            throw new RuntimeException(e); // shan't happen
+        }
+        return result.toString();
+    }
+
+    @Override
+    public void writeAsString(Appendable output, int maxDepth) throws IOException {
+        getWrapped().writeAsString(output, maxDepth);
+        appendAnnotations(output, maxDepth);
+    }
+
+    @Override
+    @Deprecated
+    public void prettyPrint(ITermPrinter pp) {
+        getWrapped().prettyPrint(pp);
+        printAnnotations(pp);
+    }
+
+    @Override
+    @Deprecated
+    public IStrategoList prepend(IStrategoTerm prefix) {
+        throw new UnsupportedOperationException();
+    }
+
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoAppl.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoAppl.java
@@ -2,37 +2,31 @@
  * Created on 28. jan.. 2007
  *
  * Copyright (c) 2005, Karl Trygve Kalleberg <karltk near strategoxt.org>
- * 
+ *
  * Licensed under the GNU Lesser General Public License, v2.1
  */
 package org.spoofax.terms;
 
+import org.spoofax.interpreter.terms.*;
+import org.spoofax.terms.util.ArrayIterator;
+
 import java.io.IOException;
 import java.util.Iterator;
 
-import org.spoofax.interpreter.terms.IStrategoAppl;
-import org.spoofax.interpreter.terms.IStrategoConstructor;
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.ITermPrinter;
-import org.spoofax.terms.util.ArrayIterator;
-
 public class StrategoAppl extends StrategoTerm implements IStrategoAppl {
 
-  private static final long serialVersionUID = -2522680523775044390L;
+    private static final long serialVersionUID = -2522680523775044390L;
 
-	private final IStrategoConstructor ctor;
+    private final IStrategoConstructor ctor;
 
     private IStrategoTerm[] kids;
 
-    public StrategoAppl(IStrategoConstructor ctor, IStrategoTerm[] kids, IStrategoList annotations, int storageType) {
-        super(annotations, storageType);
+    public StrategoAppl(IStrategoConstructor ctor, IStrategoTerm[] kids, IStrategoList annotations) {
+        super(annotations);
         this.ctor = ctor;
         this.kids = kids;
-        
-        if (storageType != MUTABLE) initImmutableHashCode();
     }
-    
+
     @Deprecated
     public IStrategoTerm[] getArguments() {
         return kids;
@@ -41,9 +35,9 @@ public class StrategoAppl extends StrategoTerm implements IStrategoAppl {
     public IStrategoConstructor getConstructor() {
         return ctor;
     }
-    
+
     public String getName() {
-    	return ctor.getName();
+        return ctor.getName();
     }
 
     public IStrategoTerm[] getAllSubterms() {
@@ -51,7 +45,7 @@ public class StrategoAppl extends StrategoTerm implements IStrategoAppl {
     }
 
     public IStrategoTerm getSubterm(int index) {
-        if (index < 0 || index >= kids.length)
+        if(index < 0 || index >= kids.length)
             throw new IndexOutOfBoundsException("Index out of bounds: " + index);
         return kids[index];
     }
@@ -65,40 +59,31 @@ public class StrategoAppl extends StrategoTerm implements IStrategoAppl {
     }
 
     @Override
-    protected boolean doSlowMatch(IStrategoTerm second, int commonStorageType) {
-        if (second.getTermType() != IStrategoTerm.APPL)
+    protected boolean doSlowMatch(IStrategoTerm second) {
+        if(second.getTermType() != IStrategoTerm.APPL)
             return false;
-        IStrategoAppl o = (IStrategoAppl)second;
-        if (!ctor.equals(o.getConstructor()))
+        IStrategoAppl o = (IStrategoAppl) second;
+        if(!ctor.equals(o.getConstructor()))
             return false;
-        
+
         IStrategoTerm[] kids = getAllSubterms();
         IStrategoTerm[] secondKids = o.getAllSubterms();
-        if (kids != secondKids) {
-            for (int i = 0, sz = kids.length; i < sz; i++) {
+        if(kids != secondKids) {
+            for(int i = 0, sz = kids.length; i < sz; i++) {
                 IStrategoTerm kid = kids[i];
                 IStrategoTerm secondKid = secondKids[i];
-                if (kid != secondKid && !kid.match(secondKid)) {
-                    if (commonStorageType == SHARABLE && i != 0)
-                        System.arraycopy(secondKids, 0, kids, 0, i);
+                if(kid != secondKid && !kid.match(secondKid)) {
                     return false;
                 }
             }
-            
-            if (commonStorageType == SHARABLE)
-                this.kids = secondKids;
         }
-        
+
         IStrategoList annotations = getAnnotations();
         IStrategoList secondAnnotations = second.getAnnotations();
-        if (annotations == secondAnnotations) {
+        if(annotations == secondAnnotations) {
             return true;
-        } else if (annotations.match(secondAnnotations)) {
-            if (commonStorageType == SHARABLE) internalSetAnnotations(secondAnnotations);
-            return true;
-        } else {
-            return false;
-        }
+        } else
+            return annotations.match(secondAnnotations);
     }
 
     @Deprecated
@@ -124,14 +109,14 @@ public class StrategoAppl extends StrategoTerm implements IStrategoAppl {
         IStrategoTerm[] kids = getAllSubterms();
         if(kids.length > 0) {
             output.append('(');
-            if (maxDepth == 0) {
-            	output.append("...");
+            if(maxDepth == 0) {
+                output.append("...");
             } else {
-	            kids[0].writeAsString(output, maxDepth - 1);
-	            for(int i = 1; i < kids.length; i++) {
-	                output.append(',');
-	                kids[i].writeAsString(output, maxDepth - 1);
-	            }
+                kids[0].writeAsString(output, maxDepth - 1);
+                for(int i = 1; i < kids.length; i++) {
+                    output.append(',');
+                    kids[i].writeAsString(output, maxDepth - 1);
+                }
             }
             output.append(')');
         }
@@ -147,10 +132,10 @@ public class StrategoAppl extends StrategoTerm implements IStrategoAppl {
             r += kids[i].hashCode() * accum;
             accum *= 7703;
         }
-        return (int)(r >> 12);
+        return (int) (r >> 12);
     }
 
-	public Iterator<IStrategoTerm> iterator() {
-		return new ArrayIterator<IStrategoTerm>(kids);
-	}
+    public Iterator<IStrategoTerm> iterator() {
+        return new ArrayIterator<IStrategoTerm>(kids);
+    }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoConstructor.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoConstructor.java
@@ -2,37 +2,33 @@
  * Created on 28. jan.. 2007
  *
  * Copyright (c) 2005, Karl Trygve Kalleberg <karltk near strategoxt.org>
- * 
+ *
  * Licensed under the GNU Lesser General Public License, v2.1
  */
 package org.spoofax.terms;
 
+import org.spoofax.interpreter.terms.*;
+import org.spoofax.terms.util.EmptyIterator;
+
 import java.io.IOException;
 import java.util.Iterator;
-
-import org.spoofax.interpreter.terms.IStrategoAppl;
-import org.spoofax.interpreter.terms.IStrategoConstructor;
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.ITermFactory;
-import org.spoofax.interpreter.terms.ITermPrinter;
-import org.spoofax.terms.util.EmptyIterator;
 
 public final class StrategoConstructor extends StrategoTerm implements IStrategoConstructor {
 
     private static final long serialVersionUID = -4477361122406081825L;
 
-	private final String name;
-    
+    private final String name;
+
     private final int arity;
 
     public StrategoConstructor(String name, int arity) {
-        super(null, SHARABLE); // MAXIMALLY_SHARED causes problems before sharing with regular hash maps
+        super(null);
         this.name = name;
         this.arity = arity;
-        if (name == null) throw new IllegalArgumentException("name cannot be null");
+        if(name == null)
+            throw new IllegalArgumentException("name cannot be null");
     }
-    
+
     public int getArity() {
         return arity;
     }
@@ -58,58 +54,58 @@ public final class StrategoConstructor extends StrategoTerm implements IStratego
     }
 
     @Override
-    protected boolean doSlowMatch(IStrategoTerm second, int commonStorageType) {
-    	if (second == this)
-    		return true;
-    	if (second == null || second.getTermType() != CTOR)
-    		return false;
-    	
-    	IStrategoConstructor other = (IStrategoConstructor) second;
-    	
+    protected boolean doSlowMatch(IStrategoTerm second) {
+        if(second == this)
+            return true;
+        if(second == null || second.getTermType() != CTOR)
+            return false;
+
+        IStrategoConstructor other = (IStrategoConstructor) second;
+
         return name.equals(other.getName()) && arity == other.getArity();
     }
 
     public void prettyPrint(ITermPrinter pp) {
         throw new UnsupportedOperationException();
     }
-    
+
     @Override
     public String toString() {
         return name + "/" + arity;
     }
-    
+
     public void writeAsString(Appendable output, int maxDepth) throws IOException {
-    	output.append(name);
-    	output.append('/');
-    	output.append(Integer.toString(arity));
+        output.append(name);
+        output.append('/');
+        output.append(Integer.toString(arity));
     }
-    
+
     public IStrategoConstructor getConstructor() {
         return this;
     }
-    
+
     @Override
     public int hashFunction() {
-    	// TODO: hash code that is reproducible from Stratego
-        return name.hashCode() + 5407 * arity; 
+        // TODO: hash code that is reproducible from Stratego
+        return name.hashCode() + 5407 * arity;
     }
 
     @Deprecated
-	public IStrategoAppl instantiate(ITermFactory factory, IStrategoTerm... kids) {
-		throw new UnsupportedOperationException();
-	}
+    public IStrategoAppl instantiate(ITermFactory factory, IStrategoTerm... kids) {
+        throw new UnsupportedOperationException();
+    }
 
-	@Deprecated
-	public IStrategoAppl instantiate(ITermFactory factory, IStrategoList kids) {
-		throw new UnsupportedOperationException();
-	}
+    @Deprecated
+    public IStrategoAppl instantiate(ITermFactory factory, IStrategoList kids) {
+        throw new UnsupportedOperationException();
+    }
 
-	public Iterator<IStrategoTerm> iterator() {
-		return new EmptyIterator<IStrategoTerm>();
-	}
-	
-	private Object readResolve() {
-		IStrategoConstructor cachedConstructor = AbstractTermFactory.createCachedConstructor(name, arity);
-		return cachedConstructor;
-	}
+    public Iterator<IStrategoTerm> iterator() {
+        return new EmptyIterator<IStrategoTerm>();
+    }
+
+    private Object readResolve() {
+        IStrategoConstructor cachedConstructor = AbstractTermFactory.createCachedConstructor(name, arity);
+        return cachedConstructor;
+    }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoInt.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoInt.java
@@ -2,13 +2,10 @@
  * Created on 28. jan.. 2007
  *
  * Copyright (c) 2005-2012, Karl Trygve Kalleberg <karltk near strategoxt.org>
- * 
+ *
  * Licensed under the GNU Lesser General Public License, v2.1
  */
 package org.spoofax.terms;
-
-import java.io.IOException;
-import java.util.Iterator;
 
 import org.spoofax.interpreter.terms.IStrategoInt;
 import org.spoofax.interpreter.terms.IStrategoList;
@@ -16,22 +13,25 @@ import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermPrinter;
 import org.spoofax.terms.util.EmptyIterator;
 
+import java.io.IOException;
+import java.util.Iterator;
+
 
 public class StrategoInt extends StrategoTerm implements IStrategoInt {
 
     private static final long serialVersionUID = 2915870332171452430L;
-	
+
     private final int value;
-    
-    public StrategoInt(int value, IStrategoList annotations, int storageType) {
-        super(annotations, storageType);
+
+    public StrategoInt(int value, IStrategoList annotations) {
+        super(annotations);
         this.value = value;
     }
-    
-    public StrategoInt(int value, int storageType) {
-        this(value, null, storageType);
+
+    public StrategoInt(int value) {
+        this(value, null);
     }
-    
+
     public int intValue() {
         return value;
     }
@@ -51,48 +51,44 @@ public class StrategoInt extends StrategoTerm implements IStrategoInt {
     public int getTermType() {
         return IStrategoTerm.INT;
     }
-    
+
     public boolean isUniqueValueTerm() {
-    	return false;
+        return false;
     }
 
     @Override
-    protected boolean doSlowMatch(IStrategoTerm second, int commonStorageType) {
+    protected boolean doSlowMatch(IStrategoTerm second) {
         if(second.getTermType() != IStrategoTerm.INT)
             return false;
 
-        if (intValue() != ((IStrategoInt) second).intValue())
-        	return false;
+        if(intValue() != ((IStrategoInt) second).intValue())
+            return false;
 
         IStrategoList annotations = getAnnotations();
         IStrategoList secondAnnotations = second.getAnnotations();
-        if (annotations == secondAnnotations) {
-        	return true;
-        } else if (annotations.match(secondAnnotations)) {
-        	if (commonStorageType == SHARABLE) internalSetAnnotations(secondAnnotations);
-        	return true;
-        } else {
-        	return false;
-        }
+        if(annotations == secondAnnotations) {
+            return true;
+        } else
+            return annotations.match(secondAnnotations);
     }
 
     @Deprecated
-	public void prettyPrint(ITermPrinter pp) {
+    public void prettyPrint(ITermPrinter pp) {
         pp.print(String.valueOf(intValue()));
         printAnnotations(pp);
     }
-    
+
     public void writeAsString(Appendable output, int maxDepth) throws IOException {
-    	output.append(Integer.toString(intValue()));
+        output.append(Integer.toString(intValue()));
         appendAnnotations(output, maxDepth);
     }
-    
+
     @Override
     public int hashFunction() {
         return 449 * intValue() ^ 7841;
     }
 
-	public Iterator<IStrategoTerm> iterator() {
-		return new EmptyIterator<IStrategoTerm>();
-	}
+    public Iterator<IStrategoTerm> iterator() {
+        return new EmptyIterator<IStrategoTerm>();
+    }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoList.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoList.java
@@ -2,107 +2,104 @@
  * Created on 9. okt.. 2006
  *
  * Copyright (c) 2005, Karl Trygve Kalleberg <karltk near strategoxt.org>
- * 
+ *
  * Licensed under the GNU Lesser General Public License, v2.1
  */
 package org.spoofax.terms;
+
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermPrinter;
 
 import java.io.IOException;
 import java.io.ObjectStreamException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.ITermPrinter;
-
 /**
  * A basic stratego list implementation using a linked-list data structure.
  */
 public class StrategoList extends StrategoTerm implements IStrategoList {
-	
-	private static final long serialVersionUID = 624120573663698628L;
 
     /**
      * @see #hashFunction()
      * @see TermFactory#EMPTY_LIST  The singleton maximally shared empty list instance.
      */
+    @SuppressWarnings("PointlessArithmeticExpression")
     static final int EMPTY_LIST_HASH = 1 * 71 * 71;
-    
-    private IStrategoTerm head;
-    
-    private IStrategoList tail;
-    
+    private static final long serialVersionUID = 624120573663698628L;
     private final int size;
+    private IStrategoTerm head;
+    private IStrategoList tail;
 
     /**
      * Creates a new list.
-     * 
+     *
      * @see #prepend(IStrategoTerm) Adds a new head element to a list.
      */
-    public StrategoList(IStrategoTerm head, IStrategoList tail, IStrategoList annotations, int storageType) {
-        super(annotations, storageType);
+    public StrategoList(IStrategoTerm head, IStrategoList tail, IStrategoList annotations) {
+        super(annotations);
         this.head = head;
         this.tail = tail;
-        
-        //if (storageType != MUTABLE) initImmutableHashCode();
-        
+
         this.size = (head == null ? 0 : 1) + (tail == null ? 0 : tail.size());
     }
-    
+
     public IStrategoTerm head() {
-        if (head == null)
+        if(head == null)
             throw new NoSuchElementException();
         return head;
     }
-    
+
     public boolean isEmpty() {
         return head == null;
     }
-    
+
     public IStrategoList tail() {
-        if (tail == null)
+        if(tail == null)
             throw new IllegalStateException();
         return tail;
     }
-    
+
     @Deprecated
     public IStrategoList prepend(IStrategoTerm prefix) {
-        return new StrategoList(prefix, this, null, TermFactory.getStorageType(prefix, this));
+        return new StrategoList(prefix, this, null);
     }
-    
+
     public final IStrategoTerm get(int index) {
         return getSubterm(index);
     }
-    
+
     public IStrategoTerm[] getAllSubterms() {
         int size = size();
         IStrategoTerm[] clone = new IStrategoTerm[size];
         IStrategoList list = this;
-        for (int i = 0; i < size; i++) {
+        for(int i = 0; i < size; i++) {
             clone[i] = list.head();
             list = list.tail();
         }
         return clone;
     }
 
-    
+
     public final int size() {
         return size;
     }
 
     public IStrategoTerm getSubterm(int index) {
         IStrategoList list = this;
-        if (index < 0) throw new IndexOutOfBoundsException("Index out of bounds: " + index);
-        for (int i = 0; i < index; i++) {
-        	if (list.isEmpty()) throw new IndexOutOfBoundsException("Index out of bounds: " + index);
+        if(index < 0)
+            throw new IndexOutOfBoundsException("Index out of bounds: " + index);
+        for(int i = 0; i < index; i++) {
+            if(list.isEmpty())
+                throw new IndexOutOfBoundsException("Index out of bounds: " + index);
             list = list.tail();
         }
         return list.head();
     }
 
     public int getSubtermCount() {
-    	return size;
+        return size;
     }
 
     public int getTermType() {
@@ -110,47 +107,38 @@ public class StrategoList extends StrategoTerm implements IStrategoList {
     }
 
     @Override
-    protected boolean doSlowMatch(IStrategoTerm second, int commonStorageType) {
-        if (second.getTermType() != IStrategoTerm.LIST)
+    protected boolean doSlowMatch(IStrategoTerm second) {
+        if(second.getTermType() != IStrategoTerm.LIST)
             return false;
-        
+
         final IStrategoList snd = (IStrategoList) second;
-        if (size() != snd.size())
+        if(size() != snd.size())
             return false;
-        
-        if (!isEmpty()) {
-        	IStrategoTerm head = head();
-        	IStrategoTerm head2 = snd.head();
-        	if (head != head2 && !head.match(head2))
-        		return false;
-        	
-        	IStrategoList tail = tail();
-        	IStrategoList tail2 = snd.tail();
-        
-        	// TODO: test equality of annos on cons nodes (see BasicStrategoList)
-	        for (IStrategoList cons = tail, cons2 = tail2; !cons.isEmpty(); cons = cons.tail(), cons2 = cons2.tail()) {
-	            IStrategoTerm consHead = cons.head();
-				IStrategoTerm cons2Head = cons2.head();
-				if (consHead != cons2Head && !consHead.match(cons2Head))
-	                return false;
-	        }
-	        
-	        if (commonStorageType == SHARABLE) {
-	        	this.head = head2;
-	        	this.tail = tail2;
-	        }
+
+        if(!isEmpty()) {
+            IStrategoTerm head = head();
+            IStrategoTerm head2 = snd.head();
+            if(head != head2 && !head.match(head2))
+                return false;
+
+            IStrategoList tail = tail();
+            IStrategoList tail2 = snd.tail();
+
+            // TODO: test equality of annos on cons nodes (see BasicStrategoList)
+            for(IStrategoList cons = tail, cons2 = tail2; !cons.isEmpty(); cons = cons.tail(), cons2 = cons2.tail()) {
+                IStrategoTerm consHead = cons.head();
+                IStrategoTerm cons2Head = cons2.head();
+                if(consHead != cons2Head && !consHead.match(cons2Head))
+                    return false;
+            }
         }
-        
+
         IStrategoList annotations = getAnnotations();
         IStrategoList secondAnnotations = second.getAnnotations();
-        if (annotations == secondAnnotations) {
-        	return true;
-        } else if (annotations.match(secondAnnotations)) {
-        	if (commonStorageType == SHARABLE) internalSetAnnotations(secondAnnotations);
-        	return true;
-        } else {
-        	return false;
-        }
+        if(annotations == secondAnnotations) {
+            return true;
+        } else
+            return annotations.match(secondAnnotations);
     }
 
     @Deprecated
@@ -159,7 +147,7 @@ public class StrategoList extends StrategoTerm implements IStrategoList {
             pp.println("[");
             pp.indent(2);
             head().prettyPrint(pp);
-            for (IStrategoList cur = tail(); !cur.isEmpty(); cur = cur.tail()) {
+            for(IStrategoList cur = tail(); !cur.isEmpty(); cur = cur.tail()) {
                 pp.print(",");
                 pp.nextIndentOff();
                 cur.head().prettyPrint(pp);
@@ -174,18 +162,18 @@ public class StrategoList extends StrategoTerm implements IStrategoList {
         }
         printAnnotations(pp);
     }
-    
+
     public void writeAsString(Appendable output, int maxDepth) throws IOException {
         output.append('[');
         if(!isEmpty()) {
-            if (maxDepth == 0) {
-            	output.append("...");
+            if(maxDepth == 0) {
+                output.append("...");
             } else {
-	            head().writeAsString(output, maxDepth - 1);
-	            for (IStrategoList cur = tail(); !cur.isEmpty(); cur = cur.tail()) {
-	                output.append(',');
-	                cur.head().writeAsString(output, maxDepth - 1);
-	            }
+                head().writeAsString(output, maxDepth - 1);
+                for(IStrategoList cur = tail(); !cur.isEmpty(); cur = cur.tail()) {
+                    output.append(',');
+                    cur.head().writeAsString(output, maxDepth - 1);
+                }
             }
         }
         output.append(']');
@@ -194,33 +182,29 @@ public class StrategoList extends StrategoTerm implements IStrategoList {
 
     @Override
     public int hashFunction() {
-    	if(head == null)
-    		return 1;
-    	
-    	final int prime = 31;
-    	int result = prime * head.hashCode();
-    	
-    	if(tail == null)
-    		return result;
-    	
-    	IStrategoList tail = this.tail;
-    	while(!tail.isEmpty()) {
-    		result = prime * result + tail.head().hashCode();
-    		tail = tail.tail();
-    	}
-    	
-    	return result;
+        if(head == null)
+            return 1;
+
+        final int prime = 31;
+        int result = prime * head.hashCode();
+
+        if(tail == null)
+            return result;
+
+        IStrategoList tail = this.tail;
+        while(!tail.isEmpty()) {
+            result = prime * result + tail.head().hashCode();
+            tail = tail.tail();
+        }
+
+        return result;
     }
 
-	public Iterator<IStrategoTerm> iterator() {
-		return new StrategoListIterator(this);
-	}
-	
-	private Object readResolve() throws ObjectStreamException {
-		if (this.isEmpty() && this.getStorageType() == MAXIMALLY_SHARED) {
-			return TermFactory.EMPTY_LIST;
-		} else {
-			return this;
-		}
-	}
+    public Iterator<IStrategoTerm> iterator() {
+        return new StrategoListIterator(this);
+    }
+
+    private Object readResolve() throws ObjectStreamException {
+        return this;
+    }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoPlaceholder.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoPlaceholder.java
@@ -1,12 +1,8 @@
 package org.spoofax.terms;
 
-import java.io.IOException;
+import org.spoofax.interpreter.terms.*;
 
-import org.spoofax.interpreter.terms.IStrategoConstructor;
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoPlaceholder;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.ITermPrinter;
+import java.io.IOException;
 
 /**
  * @author Lennart Kats <lennart add lclnet.nl>
@@ -15,50 +11,46 @@ public class StrategoPlaceholder extends StrategoAppl implements IStrategoPlaceh
 
     private static final long serialVersionUID = -1212433450601997725L;
 
-	public StrategoPlaceholder(IStrategoConstructor ctor, IStrategoTerm template, IStrategoList annotations, int storageType) {
-        super(ctor, new IStrategoTerm[] { template }, annotations, storageType);
+    public StrategoPlaceholder(IStrategoConstructor ctor, IStrategoTerm template, IStrategoList annotations) {
+        super(ctor, new IStrategoTerm[] { template }, annotations);
     }
-    
+
     public IStrategoTerm getTemplate() {
         return getSubterm(0);
     }
-    
+
     @Override
     public int getTermType() {
         return PLACEHOLDER;
     }
-    
+
     @Override
-    protected boolean doSlowMatch(IStrategoTerm second, int commonStorageType) {
-        if (second.getTermType() != PLACEHOLDER)
+    protected boolean doSlowMatch(IStrategoTerm second) {
+        if(second.getTermType() != PLACEHOLDER)
             return false;
-        
-        if (!getTemplate().match(((IStrategoPlaceholder) second).getTemplate()))
-        	return false;
-        
+
+        if(!getTemplate().match(((IStrategoPlaceholder) second).getTemplate()))
+            return false;
+
         IStrategoList annotations = getAnnotations();
         IStrategoList secondAnnotations = second.getAnnotations();
-        if (annotations == secondAnnotations) {
+        if(annotations == secondAnnotations) {
             return true;
-        } else if (annotations.match(secondAnnotations)) {
-            if (commonStorageType == SHARABLE) internalSetAnnotations(secondAnnotations);
-            return true;
-        } else {
-            return false;
-        }
+        } else
+            return annotations.match(secondAnnotations);
     }
-    
+
     @Override
-	public void writeAsString(Appendable output, int maxDepth) throws IOException {
-    	output.append('<');
-    	getTemplate().writeAsString(output, maxDepth - 1);
-    	output.append('>');
-    	appendAnnotations(output, maxDepth);
+    public void writeAsString(Appendable output, int maxDepth) throws IOException {
+        output.append('<');
+        getTemplate().writeAsString(output, maxDepth - 1);
+        output.append('>');
+        appendAnnotations(output, maxDepth);
     }
-    
+
     @Override
     @Deprecated
-	public void prettyPrint(ITermPrinter pp) {
+    public void prettyPrint(ITermPrinter pp) {
         pp.print("<");
         getTemplate().prettyPrint(pp);
         pp.print(">");

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoReal.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoReal.java
@@ -2,13 +2,10 @@
  * Created on 28. jan.. 2007
  *
  * Copyright (c) 2005, Karl Trygve Kalleberg <karltk near strategoxt.org>
- * 
+ *
  * Licensed under the GNU Lesser General Public License, v2.1
  */
 package org.spoofax.terms;
-
-import java.io.IOException;
-import java.util.Iterator;
 
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoReal;
@@ -16,22 +13,25 @@ import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermPrinter;
 import org.spoofax.terms.util.EmptyIterator;
 
+import java.io.IOException;
+import java.util.Iterator;
+
 
 public class StrategoReal extends StrategoTerm implements IStrategoReal {
 
     private static final long serialVersionUID = 9005617684098182139L;
-	
+
     private final double value;
-    
-    public StrategoReal(double value, IStrategoList annotations, int storageType) {
-        super(annotations, storageType);
+
+    public StrategoReal(double value, IStrategoList annotations) {
+        super(annotations);
         this.value = value;
     }
-    
-    protected StrategoReal(double value, int storageType) {
-        this(value, null, storageType);
+
+    protected StrategoReal(double value) {
+        this(value, null);
     }
-    
+
     public double realValue() {
         return value;
     }
@@ -53,42 +53,38 @@ public class StrategoReal extends StrategoTerm implements IStrategoReal {
     }
 
     @Override
-    protected boolean doSlowMatch(IStrategoTerm second, int commonStorageType) {
+    protected boolean doSlowMatch(IStrategoTerm second) {
         if(second.getTermType() != IStrategoTerm.REAL)
             return false;
 
-        if (realValue() != ((IStrategoReal) second).realValue())
-        	return false;
+        if(realValue() != ((IStrategoReal) second).realValue())
+            return false;
 
         IStrategoList annotations = getAnnotations();
         IStrategoList secondAnnotations = second.getAnnotations();
-        if (annotations == secondAnnotations) {
-        	return true;
-        } else if (annotations.match(secondAnnotations)) {
-        	if (commonStorageType == SHARABLE) internalSetAnnotations(secondAnnotations);
-        	return true;
-        } else {
-        	return false;
-        }
+        if(annotations == secondAnnotations) {
+            return true;
+        } else
+            return annotations.match(secondAnnotations);
     }
 
     @Deprecated
-	public void prettyPrint(ITermPrinter pp) {
+    public void prettyPrint(ITermPrinter pp) {
         pp.print("" + realValue());
         printAnnotations(pp);
     }
-    
+
     public void writeAsString(Appendable output, int maxDepth) throws IOException {
-    	output.append(Double.toString(realValue()));
+        output.append(Double.toString(realValue()));
         appendAnnotations(output, maxDepth);
     }
 
     @Override
     public int hashFunction() {
-        return (int)(449 * value) ^ 7841;
+        return (int) (449 * value) ^ 7841;
     }
 
-	public Iterator<IStrategoTerm> iterator() {
-		return new EmptyIterator<IStrategoTerm>();
-	}
+    public Iterator<IStrategoTerm> iterator() {
+        return new EmptyIterator<IStrategoTerm>();
+    }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoString.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoString.java
@@ -2,13 +2,10 @@
  * Created on 9. okt.. 2006
  *
  * Copyright (c) 2005, Karl Trygve Kalleberg <karltk near strategoxt.org>
- * 
+ *
  * Licensed under the GNU Lesser General Public License, v2.1
  */
 package org.spoofax.terms;
-
-import java.io.IOException;
-import java.util.Iterator;
 
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoString;
@@ -16,24 +13,26 @@ import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermPrinter;
 import org.spoofax.terms.util.EmptyIterator;
 
+import java.io.IOException;
+import java.util.Iterator;
+
 
 public class StrategoString extends StrategoTerm implements IStrategoString {
-	
+
     private static final long serialVersionUID = 237308007762215350L;
-	
+
     private final String value;
-    
-    public StrategoString(String value, IStrategoList annotations, int storageType) {
-        super(annotations, storageType);
+
+    public StrategoString(String value, IStrategoList annotations) {
+        super(annotations);
         this.value = value;
-        assert storageType == MAXIMALLY_SHARED ? annotations == null : true;
         initImmutableHashCode();
     }
-    
+
     protected StrategoString(String value) {
-    	this(value, TermFactory.EMPTY_LIST, IStrategoTerm.IMMUTABLE);
+        this(value, TermFactory.EMPTY_LIST);
     }
-    
+
     public IStrategoTerm getSubterm(int index) {
         throw new IndexOutOfBoundsException();
     }
@@ -41,7 +40,7 @@ public class StrategoString extends StrategoTerm implements IStrategoString {
     public IStrategoTerm[] getAllSubterms() {
         return TermFactory.EMPTY;
     }
-    
+
     public int getSubtermCount() {
         return 0;
     }
@@ -51,68 +50,56 @@ public class StrategoString extends StrategoTerm implements IStrategoString {
     }
 
     @Override
-    protected boolean doSlowMatch(IStrategoTerm second, int commonStorageType) {
+    protected boolean doSlowMatch(IStrategoTerm second) {
         if(second.getTermType() != IStrategoTerm.STRING)
             return false;
-        
+
         String value = stringValue();
         String secondValue = ((IStrategoString) second).stringValue();
-        
-        if (value == secondValue) {
-        	// Do nothing
-        } else if (value.equals(secondValue)) {
-        	// Don't apply resharing here (StrategoXT/801) but maintain
-        	// the string instance that may be in the string pool
-        	// if (commonStorageType == SHARABLE)
-        	//	this.value = secondValue;
-        } else {
+
+        if(!value.equals(secondValue)) {
             return false;
         }
 
+
         IStrategoList annotations = getAnnotations();
         IStrategoList secondAnnotations = second.getAnnotations();
-        if (annotations == secondAnnotations) {
-            // assert annotations.isEmpty() ? this == second : true : "Maximal sharing contract broken";
-        	return true;
-        } else if (annotations.match(secondAnnotations)) {
-        	if (commonStorageType == SHARABLE) internalSetAnnotations(secondAnnotations);
-        	return true;
-        } else {
-        	return false;
-        }
+        if(annotations == secondAnnotations) {
+            return true;
+        } else
+            return annotations.match(secondAnnotations);
     }
 
     public String stringValue() {
         return value;
     }
-    
+
     public String getName() {
-    	return value;
+        return value;
     }
-    
+
     @Deprecated
-	public void prettyPrint(ITermPrinter pp) {
+    public void prettyPrint(ITermPrinter pp) {
         pp.print("\"");
-        pp.print(stringValue().replace("\\", "\\\\").replace("\"", "\\\"")
-        		.replace("\n", "\\n").replace("\r", "\\r"));
+        pp.print(stringValue().replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r"));
         pp.print("\"");
         printAnnotations(pp);
     }
- 
+
     public void writeAsString(Appendable output, int maxDepth) throws IOException {
-    	output.append("\"");
-    	output.append(stringValue().replace("\\", "\\\\").replace("\"", "\\\"")
-        		.replace("\n", "\\n").replace("\r", "\\r"));
-    	output.append("\"");
+        output.append("\"");
+        output.append(
+            stringValue().replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n").replace("\r", "\\r"));
+        output.append("\"");
         appendAnnotations(output, maxDepth);
     }
-    
+
     @Override
     public int hashFunction() {
         return stringValue().hashCode();
     }
 
-	public Iterator<IStrategoTerm> iterator() {
-		return new EmptyIterator<IStrategoTerm>();
-	}
+    public Iterator<IStrategoTerm> iterator() {
+        return new EmptyIterator<IStrategoTerm>();
+    }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoTerm.java
@@ -2,214 +2,160 @@
  * Created on 2. feb.. 2007
  *
  * Copyright (c) 2005, Karl Trygve Kalleberg <karltk near strategoxt.org>
- * 
+ *
  * Licensed under the GNU Lesser General Public License, v2.1
  */
 package org.spoofax.terms;
-
-import static org.spoofax.terms.TermFactory.EMPTY_LIST;
-
-import java.io.IOException;
 
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermPrinter;
 
+import java.io.IOException;
+
+import static org.spoofax.terms.TermFactory.EMPTY_LIST;
+
 public abstract class StrategoTerm extends AbstractSimpleTerm implements IStrategoTerm, Cloneable {
-	
-	private static final long serialVersionUID = -2803845954655431574L;
 
-	private static final int UNKNOWN_HASH = -1;
-	
-	private static final int MUTABLE_HASH = MUTABLE;
+    private static final long serialVersionUID = -2803845954655431574L;
 
-	private final int storageType;
-	
-	private transient int hashCode = UNKNOWN_HASH;
+    private static final int UNKNOWN_HASH = -1;
+
+    private transient int hashCode = UNKNOWN_HASH;
 
     private IStrategoList annotations;
-    
-    protected StrategoTerm(IStrategoList annotations, int storageType) {
+
+    protected StrategoTerm(IStrategoList annotations) {
         assert annotations == null || !annotations.isEmpty() || annotations == TermFactory.EMPTY_LIST;
-    	if (annotations != TermFactory.EMPTY_LIST)
-    		this.annotations = annotations;
-    	this.storageType = storageType;
+        if(annotations != TermFactory.EMPTY_LIST)
+            this.annotations = annotations;
     }
-    
-    protected StrategoTerm(int storageType) {
-    	this(null, storageType);
-    }
-    
-    public final int getStorageType() {
-    	return storageType;
+
+    protected StrategoTerm() {
+        this(null);
     }
 
     /**
      * Equality test.
-     * 
-     * @note
-     *   For {@link #SHARABLE} terms if a term 'x' is matched with multiple times,
-     *   it should always appear as the argument of the match calls.
-     *   Likewise, longer-lived terms should appear in this position. 
      */
     public final boolean match(IStrategoTerm second) {
-    	if (this == second) return true;
-    	if (second == null) return false;
-        
-    	int storageType = getStorageType();
-        
-		switch (storageType) {
-        	case MAXIMALLY_SHARED:
-        		switch (second.getStorageType()) {
-					case MAXIMALLY_SHARED:
-						return false;
-					case SHARABLE:
-						// (common storage type is immutable, i.e. my subterms should not be overwritten)
-						return hashCode() == second.hashCode() && doSlowMatch(second, IMMUTABLE);
-					case IMMUTABLE:
-						return hashCode() == second.hashCode() && doSlowMatch(second, IMMUTABLE);
-	    			default:
-	    				return doSlowMatch(second, MUTABLE);
-	    		}
-        	case SHARABLE:
-        	case IMMUTABLE:
-        		switch (second.getStorageType()) {
-    				case MAXIMALLY_SHARED:
-    					return hashCode() == second.hashCode() && doSlowMatch(second, storageType);
-    				case SHARABLE:
-    					return hashCode() == second.hashCode() && doSlowMatch(second, storageType);
-    				case IMMUTABLE:
-    					return hashCode() == second.hashCode() && doSlowMatch(second, IMMUTABLE);
-        			default:
-        				return doSlowMatch(second, MUTABLE);
-        		}
-        	default:
-     			return doSlowMatch(second, MUTABLE);
+        if(this == second)
+            return true;
+        if(second == null)
+            return false;
+
+        return hashCode() == second.hashCode() && doSlowMatch(second);
+    }
+
+    protected abstract boolean doSlowMatch(IStrategoTerm second);
+
+    @Override
+    public final boolean equals(Object obj) {
+        if(obj == this)
+            return true;
+        if(!(obj instanceof IStrategoTerm))
+            return false;
+        return match((IStrategoTerm) obj);
+    }
+
+    @Override
+    public int hashCode() {
+	    if(hashCode == UNKNOWN_HASH) {
+            initImmutableHashCode();
+        }
+        return hashCode;
+    }
+
+    protected final void initImmutableHashCode() {
+        int hashCode = hashFunction();
+        if(annotations == null || annotations == EMPTY_LIST || annotations.isEmpty()) {
+            this.hashCode = hashCode;
+        } else {
+            this.hashCode = hashCode * 2423 + annotations.hashCode();
         }
     }
 
-    protected abstract boolean doSlowMatch(IStrategoTerm second, int commonStorageType);
-    
-    @Override
-    public final boolean equals(Object obj) {
-    	if (obj == this) return true;
-        if(!(obj instanceof IStrategoTerm)) return false;
-        return match((IStrategoTerm)obj);
-    }
-    
-    @Override
-    public int hashCode() {
-    	int result = hashCode;
-    	switch (result) {
-    		case MUTABLE_HASH:
-    			result = hashFunction();
-    			if (annotations != null && annotations != EMPTY_LIST && !annotations.isEmpty())
-    				result = result * 2423 + annotations.hashCode();
-    			return result;
-    		case UNKNOWN_HASH:
-    			result = hashFunction();
-    			if (annotations != null && annotations != EMPTY_LIST && !annotations.isEmpty())
-    				result = result * 2423 + annotations.hashCode();
-   				hashCode = getTermType() == MUTABLE ? MUTABLE_HASH : result;
-    			return result;
-    		default:
-    			return result;
-    	}
-    }
-    
-    protected final void initImmutableHashCode() {
-    	assert getTermType() != MUTABLE; // (avoid this virtual call here)
-    	if (hashCode == UNKNOWN_HASH) {
-    		int hashCode = hashFunction();
-			this.hashCode = annotations == null || annotations == EMPTY_LIST || annotations.isEmpty()
-				? hashCode
-				: hashCode * 2423 + annotations.hashCode();
-    	}
-    }
-    
     protected abstract int hashFunction();
-    
+
     @Override
     public String toString() {
-    	return toString(Integer.MAX_VALUE);
-    }
-    
-    public String toString(int maxDepth) {
-    	StringBuilder result = new StringBuilder();
-    	try {
-    		writeAsString(result, maxDepth);
-    	} catch (IOException e) {
-    		throw new RuntimeException(e); // shan't happen
-    	}
-    	return result.toString();
-    }
-    
-    public final void writeToString(Appendable output) throws IOException {
-    	writeAsString(output, Integer.MAX_VALUE);
+        return toString(Integer.MAX_VALUE);
     }
 
-	protected void appendAnnotations(Appendable sb, int maxDepth) throws IOException {
+    public String toString(int maxDepth) {
+        StringBuilder result = new StringBuilder();
+        try {
+            writeAsString(result, maxDepth);
+        } catch(IOException e) {
+            throw new RuntimeException(e); // shan't happen
+        }
+        return result.toString();
+    }
+
+    public final void writeToString(Appendable output) throws IOException {
+        writeAsString(output, Integer.MAX_VALUE);
+    }
+
+    protected void appendAnnotations(Appendable sb, int maxDepth) throws IOException {
         IStrategoList annos = getAnnotations();
-        if (annos.size() == 0) return;
-        
+        if(annos.size() == 0)
+            return;
+
         sb.append('{');
         annos.getSubterm(0).writeAsString(sb, maxDepth);
-        for (annos = annos.tail(); !annos.isEmpty(); annos = annos.tail()) {
+        for(annos = annos.tail(); !annos.isEmpty(); annos = annos.tail()) {
             sb.append(',');
-            annos.head().writeAsString(sb, maxDepth);        	
+            annos.head().writeAsString(sb, maxDepth);
         }
         sb.append('}');
     }
-    
-	@Deprecated
-	protected void printAnnotations(ITermPrinter pp) {
+
+    @Deprecated
+    protected void printAnnotations(ITermPrinter pp) {
         IStrategoList annos = getAnnotations();
-        if (annos.size() == 0) return;
-        
+        if(annos.size() == 0)
+            return;
+
         pp.print("{");
         annos.head().prettyPrint(pp);
-        for (annos = annos.tail(); !annos.isEmpty(); annos = annos.tail()) {
-        	pp.print(",");
-        	annos.head().prettyPrint(pp);        	
+        for(annos = annos.tail(); !annos.isEmpty(); annos = annos.tail()) {
+            pp.print(",");
+            annos.head().prettyPrint(pp);
         }
         pp.print("}");
     }
-    
+
     @Override
     protected StrategoTerm clone() {
         try {
-        	assert getStorageType() != MAXIMALLY_SHARED;
             return (StrategoTerm) super.clone();
-        } catch (CloneNotSupportedException e) {
+        } catch(CloneNotSupportedException e) {
             throw new RuntimeException(e); // silly checked exceptions...
         }
     }
-    
+
     public StrategoTerm clone(boolean stripAttachments) {
-    	StrategoTerm result = clone();
-    	if (stripAttachments)
-    		result.clearAttachments();
-    	return result;
+        StrategoTerm result = clone();
+        if(stripAttachments)
+            result.clearAttachments();
+        return result;
     }
-    
+
     public final IStrategoList getAnnotations() {
         return annotations == null ? TermFactory.EMPTY_LIST : annotations;
     }
-    
+
     public final void internalSetAnnotations(IStrategoList annotations) {
-    	if (annotations == TermFactory.EMPTY_LIST || annotations.isEmpty())
-    		annotations = null; // essential for hash code calculation
-    	
-    	assert getTermType() != STRING || getStorageType() != MAXIMALLY_SHARED :
-    		"Maximally shared, unannotated string must be created using constructor";
-    	
-    	if (this.annotations != annotations) {
-    		this.annotations = annotations;
-    		this.hashCode = UNKNOWN_HASH;
-    	}
+        if(annotations == TermFactory.EMPTY_LIST || annotations.isEmpty())
+            annotations = null; // essential for hash code calculation
+
+        if(this.annotations != annotations) {
+            this.annotations = annotations;
+            this.hashCode = UNKNOWN_HASH;
+        }
     }
-    
+
     public final boolean isList() {
-    	return getTermType() == LIST;
+        return getTermType() == LIST;
     }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoTuple.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoTuple.java
@@ -2,13 +2,10 @@
  * Created on 9. okt.. 2006
  *
  * Copyright (c) 2005, Karl Trygve Kalleberg <karltk near strategoxt.org>
- * 
+ *
  * Licensed under the GNU Lesser General Public License, v2.1
  */
 package org.spoofax.terms;
-
-import java.io.IOException;
-import java.util.Iterator;
 
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
@@ -16,20 +13,20 @@ import org.spoofax.interpreter.terms.IStrategoTuple;
 import org.spoofax.interpreter.terms.ITermPrinter;
 import org.spoofax.terms.util.ArrayIterator;
 
+import java.io.IOException;
+import java.util.Iterator;
+
 public class StrategoTuple extends StrategoTerm implements IStrategoTuple {
 
     private static final long serialVersionUID = -6034069486754146955L;
-	
+
     private IStrategoTerm[] kids;
-    
-    public StrategoTuple(IStrategoTerm[] kids, IStrategoList annotations, int storageType) {
-        super(annotations, storageType);
+
+    public StrategoTuple(IStrategoTerm[] kids, IStrategoList annotations) {
+        super(annotations);
         this.kids = kids;
-        
-        // (not pre-initializing hash code here; tuples are mostly short-lived)
-        // if (storageType != MUTABLE) initImmutableHashCode();
     }
-    
+
     public IStrategoTerm get(int index) {
         return kids[index];
     }
@@ -39,7 +36,7 @@ public class StrategoTuple extends StrategoTerm implements IStrategoTuple {
         System.arraycopy(kids, 0, r, 0, kids.length);
         return r;
     }
-    
+
     public int size() {
         return kids.length;
     }
@@ -57,41 +54,32 @@ public class StrategoTuple extends StrategoTerm implements IStrategoTuple {
     }
 
     @Override
-    protected boolean doSlowMatch(IStrategoTerm second, int commonStorageType) {
-        if (second.getTermType() != IStrategoTerm.TUPLE)
+    protected boolean doSlowMatch(IStrategoTerm second) {
+        if(second.getTermType() != IStrategoTerm.TUPLE)
             return false;
 
         IStrategoTuple snd = (IStrategoTuple) second;
-        if (size() != snd.size())
+        if(size() != snd.size())
             return false;
-        
+
         IStrategoTerm[] kids = this.kids;
         IStrategoTerm[] secondKids = snd.getAllSubterms();
-        if (kids != secondKids) {
-	        for (int i = 0, sz = kids.length; i < sz; i++) {
-	            IStrategoTerm kid = kids[i];
-				IStrategoTerm secondKid = secondKids[i];
-				if (kid != secondKid && !kid.match(secondKid)) {
-	            	if (commonStorageType == SHARABLE && i != 0)
-	            		System.arraycopy(secondKids, 0, kids, 0, i);
-	                return false;
-	            }
-	        }
-	        
-	    	if (commonStorageType == SHARABLE)
-	    		this.kids = secondKids;
+        if(kids != secondKids) {
+            for(int i = 0, sz = kids.length; i < sz; i++) {
+                IStrategoTerm kid = kids[i];
+                IStrategoTerm secondKid = secondKids[i];
+                if(kid != secondKid && !kid.match(secondKid)) {
+                    return false;
+                }
+            }
         }
-        
+
         IStrategoList annotations = getAnnotations();
         IStrategoList secondAnnotations = second.getAnnotations();
-        if (annotations == secondAnnotations) {
-        	return true;
-        } else if (annotations.match(secondAnnotations)) {
-        	if (commonStorageType == SHARABLE) internalSetAnnotations(secondAnnotations);
-        	return true;
-        } else {
-        	return false;
-        }
+        if(annotations == secondAnnotations) {
+            return true;
+        } else
+            return annotations.match(secondAnnotations);
     }
 
     @Deprecated
@@ -116,36 +104,36 @@ public class StrategoTuple extends StrategoTerm implements IStrategoTuple {
         }
         printAnnotations(pp);
     }
-    
+
     public void writeAsString(Appendable output, int maxDepth) throws IOException {
         output.append('(');
         IStrategoTerm[] kids = getAllSubterms();
-		if (kids.length > 0) {
-			if (maxDepth == 0) {
-				output.append("...");
-			} else {
-				kids[0].writeAsString(output, maxDepth - 1);
-				for (int i = 1; i < kids.length; i++) {
-					output.append(',');
-					kids[i].writeAsString(output, maxDepth - 1);
-				}
-			}
-		}
+        if(kids.length > 0) {
+            if(maxDepth == 0) {
+                output.append("...");
+            } else {
+                kids[0].writeAsString(output, maxDepth - 1);
+                for(int i = 1; i < kids.length; i++) {
+                    output.append(',');
+                    kids[i].writeAsString(output, maxDepth - 1);
+                }
+            }
+        }
         output.append(')');
         appendAnnotations(output, maxDepth);
     }
-    
+
     @Override
     public int hashFunction() {
         long hc = 4831;
         IStrategoTerm[] kids = getAllSubterms();
-        for(int i=0; i< kids.length;i++) {
+        for(int i = 0; i < kids.length; i++) {
             hc *= kids[i].hashCode();
         }
-        return (int)(hc >> 10);
+        return (int) (hc >> 10);
     }
 
-	public Iterator<IStrategoTerm> iterator() {
-		return new ArrayIterator<IStrategoTerm>(kids);
-	}
+    public Iterator<IStrategoTerm> iterator() {
+        return new ArrayIterator<IStrategoTerm>(kids);
+    }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoWrapped.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoWrapped.java
@@ -46,7 +46,7 @@ public class StrategoWrapped extends StrategoTerm implements IStrategoAppl, IStr
 	 * {@link #prettyPrint(ITermPrinter)}.
 	 */
 	protected StrategoWrapped(IStrategoTerm wrapped, IStrategoList annotations) {
-		super(annotations, MUTABLE);
+		super(annotations);
 		this.wrapped = wrapped;
 	}
 	
@@ -62,7 +62,7 @@ public class StrategoWrapped extends StrategoTerm implements IStrategoAppl, IStr
 	}
 	
 	@Override
-	protected boolean doSlowMatch(IStrategoTerm second, int commonStorageType) {
+	protected boolean doSlowMatch(IStrategoTerm second) {
 		return wrapped.match(second);
 	}
 

--- a/org.spoofax.terms/src/org/spoofax/terms/TermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/TermFactory.java
@@ -1,13 +1,5 @@
 package org.spoofax.terms;
 
-import static java.lang.Math.min;
-import static org.spoofax.interpreter.terms.IStrategoTerm.*;
-
-import java.lang.ref.WeakReference;
-import java.util.Collections;
-import java.util.Set;
-import java.util.WeakHashMap;
-
 import org.spoofax.interpreter.terms.IStrategoAppl;
 import org.spoofax.interpreter.terms.IStrategoConstructor;
 import org.spoofax.interpreter.terms.IStrategoInt;
@@ -20,6 +12,8 @@ import org.spoofax.interpreter.terms.IStrategoTuple;
 import org.spoofax.interpreter.terms.ITermFactory;
 import org.spoofax.terms.util.StringInterner;
 
+import static org.spoofax.interpreter.terms.IStrategoTerm.STRING;
+
 public class TermFactory extends AbstractTermFactory implements ITermFactory {
     private static final int MAX_POOLED_STRING_LENGTH = 200;
     private static final StringInterner usedStrings = new StringInterner();
@@ -28,71 +22,54 @@ public class TermFactory extends AbstractTermFactory implements ITermFactory {
 
 
     public TermFactory() {
-        super(SHARABLE);
+        super();
     }
 
-
-    public ITermFactory getFactoryWithStorageType(int storageType) {
-        if(storageType > SHARABLE)
-            throw new UnsupportedOperationException();
-        if(storageType == defaultStorageType)
-            return this;
-        TermFactory result = new TermFactory();
-        result.defaultStorageType = storageType;
-        return result;
-    }
-
-    @Override public IStrategoAppl makeAppl(IStrategoConstructor ctr, IStrategoTerm[] terms,
-        IStrategoList annotations) {
-        int storageType = defaultStorageType;
-        storageType = min(storageType, getStorageType(terms));
-        if(storageType != 0)
-            storageType = min(storageType, getStorageType(annotations));
+    @Override
+    public IStrategoAppl makeAppl(IStrategoConstructor ctr, IStrategoTerm[] terms, IStrategoList annotations) {
         assert ctr.getArity() == terms.length;
-        return new StrategoAppl(ctr, terms, annotations, storageType);
+        return new StrategoAppl(ctr, terms, annotations);
     }
 
     public IStrategoInt makeInt(int i) {
-        return new StrategoInt(i, null, defaultStorageType);
+        return new StrategoInt(i, null);
     }
 
-    @Override public IStrategoList makeList() {
-        return isTermSharingAllowed() ? EMPTY_LIST : new StrategoList(null, null, null, defaultStorageType);
+    @Override
+    public IStrategoList makeList() {
+        return new StrategoList(null, null, null);
     }
 
-    @Override public IStrategoList makeList(IStrategoTerm[] terms, IStrategoList outerAnnos) {
-        int storageType = defaultStorageType;
+    @Override
+    public IStrategoList makeList(IStrategoTerm[] terms, IStrategoList outerAnnos) {
         IStrategoList result = makeList();
         int i = terms.length - 1;
         while(i > 0) {
             IStrategoTerm head = terms[i--];
-            storageType = min(storageType, getStorageType(head));
-            result = new StrategoList(head, result, null, storageType);
+            result = new StrategoList(head, result, null);
         }
         if(i == 0) {
             IStrategoTerm head = terms[0];
-            storageType = min(storageType, getStorageType(head));
-            result = new StrategoList(head, result, outerAnnos, storageType);
+            result = new StrategoList(head, result, outerAnnos);
         } else {
             if(outerAnnos == null || outerAnnos.isEmpty()) {
                 return makeList();
             } else {
-                return new StrategoList(null, null, outerAnnos, defaultStorageType);
+                return new StrategoList(null, null, outerAnnos);
             }
         }
         return result;
     }
 
-    @Override public IStrategoList makeListCons(IStrategoTerm head, IStrategoList tail, IStrategoList annotations) {
-        int storageType = min(defaultStorageType, getStorageType(head, tail));
-
+    @Override
+    public IStrategoList makeListCons(IStrategoTerm head, IStrategoList tail, IStrategoList annotations) {
         if(head == null)
             return makeList();
-        return new StrategoList(head, tail, annotations, storageType);
+        return new StrategoList(head, tail, annotations);
     }
 
     public IStrategoReal makeReal(double d) {
-        return new StrategoReal(d, null, defaultStorageType);
+        return new StrategoReal(d, null);
     }
 
     public IStrategoString makeString(String s) {
@@ -101,7 +78,7 @@ public class TermFactory extends AbstractTermFactory implements ITermFactory {
                 s = usedStrings.intern(s);
             }
         }
-        return new StrategoString(s, null, defaultStorageType);
+        return new StrategoString(s, null);
     }
 
     public IStrategoString tryMakeUniqueString(String s) {
@@ -116,44 +93,20 @@ public class TermFactory extends AbstractTermFactory implements ITermFactory {
         }
     }
 
-    @Override public IStrategoTuple makeTuple(IStrategoTerm[] terms, IStrategoList annos) {
-        int storageType = min(defaultStorageType, getStorageType(terms));
-        return new StrategoTuple(terms, annos, storageType);
+    @Override
+    public IStrategoTuple makeTuple(IStrategoTerm[] terms, IStrategoList annos) {
+        return new StrategoTuple(terms, annos);
     }
 
     public IStrategoTerm annotateTerm(IStrategoTerm term, IStrategoList annotations) {
         IStrategoList currentAnnos = term.getAnnotations();
         if(currentAnnos == annotations) { // cheap check
             return term;
-        } else if(term.getStorageType() == MAXIMALLY_SHARED) {
-            if(term == EMPTY_LIST) {
-                if(annotations == EMPTY_LIST || annotations.isEmpty()) {
-                    return EMPTY_LIST;
-                } else {
-                    return new StrategoList(null, null, annotations, defaultStorageType);
-                }
-            } else if(term.getTermType() == STRING) {
-                String value = ((IStrategoString) term).stringValue();
-                if(annotations == EMPTY_LIST || annotations.isEmpty()) {
-                    return makeString(value);
-                } else {
-                    return new StrategoString(value, annotations, defaultStorageType);
-                }
-            } else if(currentAnnos == EMPTY_LIST) {
-                return annotations.isEmpty() ? term : new StrategoAnnotation(this, term, annotations);
-            } else if(term instanceof StrategoAnnotation) {
-                term = ((StrategoAnnotation) term).getWrapped();
-                // int storageType = min(defaultStorageType, getStorageType(term));
-                return new StrategoAnnotation(this, term, annotations);
-            } else {
-                throw new UnsupportedOperationException("Unable to annotate term of type " + term.getClass().getName());
-            }
         } else if((annotations == EMPTY_LIST || annotations.isEmpty()) && term.getTermType() == STRING) {
             return makeString(((IStrategoString) term).stringValue());
         } else if(term instanceof StrategoTerm) {
             StrategoTerm result = ((StrategoTerm) term).clone(true);
             result.internalSetAnnotations(annotations);
-            assert result.getStorageType() != MAXIMALLY_SHARED;
             return result;
         } else {
             throw new UnsupportedOperationException(
@@ -164,6 +117,6 @@ public class TermFactory extends AbstractTermFactory implements ITermFactory {
     public IStrategoPlaceholder makePlaceholder(IStrategoTerm template) {
         if(placeholderConstructor == null)
             placeholderConstructor = makeConstructor("<>", 1);
-        return new StrategoPlaceholder(placeholderConstructor, template, TermFactory.EMPTY_LIST, defaultStorageType);
+        return new StrategoPlaceholder(placeholderConstructor, template, TermFactory.EMPTY_LIST);
     }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/UniqueValueTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/UniqueValueTerm.java
@@ -33,10 +33,6 @@ public final class UniqueValueTerm extends AbstractSimpleTerm implements IStrate
 		return TermFactory.EMPTY_LIST;
 	}
 
-	public int getStorageType() {
-		return MUTABLE; // allow attachments
-	}
-
 	public IStrategoTerm getSubterm(int index) {
 		throw new UnsupportedOperationException();
 	}

--- a/org.spoofax.terms/src/org/spoofax/terms/attachments/AbstractWrappedTermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/attachments/AbstractWrappedTermFactory.java
@@ -19,10 +19,8 @@ public abstract class AbstractWrappedTermFactory extends AbstractTermFactory {
 	
 	private final ITermFactory baseFactory;
 	
-	public AbstractWrappedTermFactory(int storageType, ITermFactory baseFactory) {
-		super(storageType);
-		this.baseFactory = baseFactory.getFactoryWithStorageType(storageType);
-		assert checkStorageType(this.baseFactory, storageType);
+	public AbstractWrappedTermFactory(ITermFactory baseFactory) {
+		this.baseFactory = baseFactory;
 	}
 
 	public IStrategoPlaceholder makePlaceholder(IStrategoTerm template) {

--- a/org.spoofax.terms/src/org/spoofax/terms/attachments/OriginTermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/attachments/OriginTermFactory.java
@@ -1,6 +1,5 @@
 package org.spoofax.terms.attachments;
 
-import static org.spoofax.interpreter.terms.IStrategoTerm.MUTABLE;
 import static org.spoofax.terms.attachments.OriginAttachment.getOrigin;
 
 import org.spoofax.interpreter.terms.IStrategoAppl;
@@ -38,13 +37,8 @@ public abstract class OriginTermFactory extends AbstractWrappedTermFactory {
 	}
 
 	public OriginTermFactory(ITermFactory baseFactory) {
-		super(MUTABLE, baseFactory);
+		super(baseFactory);
 		assert !(baseFactory instanceof OriginTermFactory);
-	}
-
-	public ITermFactory getFactoryWithStorageType(int storageType) {
-		assert getDefaultStorageType() <= storageType;
-		return this;
 	}
 	
 	/**
@@ -125,8 +119,7 @@ public abstract class OriginTermFactory extends AbstractWrappedTermFactory {
 				return makeListLink((IStrategoList) term, (IStrategoList) origin);
 			}
 		} else if (OriginAttachment.get(term) == null) {
-			if (term.getStorageType() == MUTABLE) // TODO: handle mutable terms (e.g., some literals)
-				OriginAttachment.setOrigin(term, origin);
+			OriginAttachment.setOrigin(term, origin);
 		} else if (REASSIGN_ORIGINS) {
 			throw new NotImplementedException("Not implemented: unwrapping of possibly already wrapped term");
 			/*
@@ -145,8 +138,7 @@ public abstract class OriginTermFactory extends AbstractWrappedTermFactory {
 	 */
 	public IStrategoTerm makeLinkDesugared(IStrategoTerm term, IStrategoTerm desugared) {
 		if (!term.isList() && DesugaredOriginAttachment.get(term) == null) {
-			if (term.getStorageType() == MUTABLE)
-				DesugaredOriginAttachment.setDesugaredOrigin(term, desugared);
+			DesugaredOriginAttachment.setDesugaredOrigin(term, desugared);
 		} else if (REASSIGN_ORIGINS) {
 			throw new NotImplementedException("Not implemented: unwrapping of possibly already wrapped term");
 		}

--- a/org.spoofax.terms/src/org/spoofax/terms/attachments/ParentTermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/attachments/ParentTermFactory.java
@@ -1,6 +1,5 @@
 package org.spoofax.terms.attachments;
 
-import static org.spoofax.interpreter.terms.IStrategoTerm.MUTABLE;
 import static org.spoofax.terms.attachments.ParentAttachment.getParent;
 import static org.spoofax.terms.attachments.ParentAttachment.putParent;
 import static org.spoofax.terms.Term.*;
@@ -30,15 +29,9 @@ public class ParentTermFactory extends AbstractTermFactory {
 	private final ITermFactory baseFactory;
 
 	public ParentTermFactory(ITermFactory baseFactory) {
-		super(MUTABLE);
+		super();
 		assert !(baseFactory instanceof ParentTermFactory);
-		this.baseFactory = baseFactory.getFactoryWithStorageType(MUTABLE);
-		assert checkStorageType(this.baseFactory, MUTABLE);
-	}
-
-	public ITermFactory getFactoryWithStorageType(int storageType) {
-		assert getDefaultStorageType() <= storageType;
-		return this;
+		this.baseFactory = baseFactory;
 	}
 
 	public IStrategoPlaceholder makePlaceholder(IStrategoTerm template) {

--- a/org.spoofax.terms/src/org/spoofax/terms/io/AbstractIOTermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/io/AbstractIOTermFactory.java
@@ -26,8 +26,8 @@ public abstract class AbstractIOTermFactory extends AbstractTermFactory implemen
 
 	private final TAFTermReader reader = new TermReader(this);
 	
-	public AbstractIOTermFactory(int defaultStorageType) {
-		super(defaultStorageType);
+	public AbstractIOTermFactory() {
+		super();
 	}
 
     public IStrategoTerm parseFromStream(InputStream inputStream) throws IOException, ParseError {

--- a/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoAppl.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoAppl.java
@@ -16,8 +16,8 @@ public abstract class SkeletonStrategoAppl extends StrategoTerm implements IStra
 
 	private static final long serialVersionUID = -2522680523775044390L;
 
-	public SkeletonStrategoAppl(IStrategoList annotations, int storageType) {
-		super(annotations, storageType);
+	public SkeletonStrategoAppl(IStrategoList annotations) {
+		super(annotations);
 	}
 
 	@Deprecated
@@ -38,7 +38,7 @@ public abstract class SkeletonStrategoAppl extends StrategoTerm implements IStra
 	}
 
 	@Override
-	final protected boolean doSlowMatch(IStrategoTerm second, int commonStorageType) {
+	final protected boolean doSlowMatch(IStrategoTerm second) {
 		if(second.getTermType() != IStrategoTerm.APPL)
 			return false;
 		final IStrategoAppl o = (IStrategoAppl) second;
@@ -52,28 +52,17 @@ public abstract class SkeletonStrategoAppl extends StrategoTerm implements IStra
 				final IStrategoTerm kid = kids[i];
 				final IStrategoTerm secondKid = secondKids[i];
 				if(kid != secondKid && !kid.match(secondKid)) {
-					if(commonStorageType == SHARABLE && i != 0)
-						System.arraycopy(secondKids, 0, kids, 0, i);
 					return false;
 				}
 			}
-
-			// FIXME should update sharing when possible
-			// if (commonStorageType == SHARABLE)
-			// this.kids = secondKids;
 		}
 
 		final IStrategoList annotations = getAnnotations();
 		final IStrategoList secondAnnotations = second.getAnnotations();
 		if(annotations == secondAnnotations) {
 			return true;
-		} else if(annotations.match(secondAnnotations)) {
-			if(commonStorageType == SHARABLE)
-				internalSetAnnotations(secondAnnotations);
-			return true;
-		} else {
-			return false;
-		}
+		} else
+			return annotations.match(secondAnnotations);
 	}
 
 	final public void writeAsString(Appendable output, int maxDepth) throws IOException {

--- a/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoInt.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoInt.java
@@ -1,13 +1,9 @@
 /*
  * Copyright (c) 2005-2012, Karl Trygve Kalleberg <karltk near strategoxt dot org>
- * 
+ *
  * Licensed under the GNU Lesser General Public License, v2.1
  */
 package org.spoofax.terms.skeleton;
-
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.Iterator;
 
 import org.spoofax.interpreter.terms.IStrategoInt;
 import org.spoofax.interpreter.terms.IStrategoList;
@@ -18,21 +14,25 @@ import org.spoofax.terms.TermFactory;
 import org.spoofax.terms.util.EmptyIterator;
 import org.spoofax.terms.util.NotImplementedException;
 
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Iterator;
+
 public class SkeletonStrategoInt extends StrategoTerm implements IStrategoInt {
 
     private static final long serialVersionUID = 2915870332171452430L;
-	
+
     private final BigInteger value;
-    
-    public SkeletonStrategoInt(long value, IStrategoList annotations, int storageType) {
-        super(annotations, storageType);
+
+    public SkeletonStrategoInt(long value, IStrategoList annotations) {
+        super(annotations);
         this.value = BigInteger.valueOf(value);
     }
-    
-    public SkeletonStrategoInt(int value, int storageType) {
-        this(value, null, storageType);
+
+    public SkeletonStrategoInt(int value) {
+        this(value, null);
     }
-    
+
     public int intValue() {
         return value.intValue();
     }
@@ -52,47 +52,43 @@ public class SkeletonStrategoInt extends StrategoTerm implements IStrategoInt {
     public int getTermType() {
         return IStrategoTerm.INT;
     }
-    
+
     public boolean isUniqueValueTerm() {
-    	return false;
+        return false;
     }
 
     @Override
-    protected boolean doSlowMatch(IStrategoTerm second, int commonStorageType) {
+    protected boolean doSlowMatch(IStrategoTerm second) {
         if(second.getTermType() != IStrategoTerm.INT)
             return false;
 
-        if (intValue() != ((IStrategoInt) second).intValue())
-        	return false;
+        if(intValue() != ((IStrategoInt) second).intValue())
+            return false;
 
         IStrategoList annotations = getAnnotations();
         IStrategoList secondAnnotations = second.getAnnotations();
-        if (annotations == secondAnnotations) {
-        	return true;
-        } else if (annotations.match(secondAnnotations)) {
-        	if (commonStorageType == SHARABLE) internalSetAnnotations(secondAnnotations);
-        	return true;
-        } else {
-        	return false;
-        }
+        if(annotations == secondAnnotations) {
+            return true;
+        } else
+            return annotations.match(secondAnnotations);
     }
 
     @Deprecated
-	public void prettyPrint(ITermPrinter pp) {
-    	throw new NotImplementedException();
+    public void prettyPrint(ITermPrinter pp) {
+        throw new NotImplementedException();
     }
-    
+
     public void writeAsString(Appendable output, int maxDepth) throws IOException {
-    	output.append(Integer.toString(intValue()));
+        output.append(Integer.toString(intValue()));
         appendAnnotations(output, maxDepth);
     }
-    
+
     @Override
     public int hashFunction() {
         return 449 * intValue() ^ 7841;
     }
-    
-	public Iterator<IStrategoTerm> iterator() {
-		return new EmptyIterator<IStrategoTerm>();
-	}
+
+    public Iterator<IStrategoTerm> iterator() {
+        return new EmptyIterator<IStrategoTerm>();
+    }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoList.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoList.java
@@ -5,28 +5,21 @@
  */
 package org.spoofax.terms.skeleton;
 
-import java.io.IOException;
-import java.util.Iterator;
-
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermPrinter;
 import org.spoofax.terms.StrategoListIterator;
 import org.spoofax.terms.StrategoTerm;
-import org.spoofax.terms.TermFactory;
 import org.spoofax.terms.attachments.ITermAttachment;
 import org.spoofax.terms.attachments.TermAttachmentType;
 import org.spoofax.terms.util.NotImplementedException;
 
+import java.io.IOException;
+import java.util.Iterator;
+
 public abstract class SkeletonStrategoList extends StrategoTerm implements IStrategoList, Iterable<IStrategoTerm> {
 
     private static final long serialVersionUID = 624120573663698628L;
-
-    /**
-     * @see #hashFunction()
-     * @see TermFactory#EMPTY_LIST  The singleton maximally shared empty list instance.
-     */
-    static final int EMPTY_LIST_HASH = 1 * 71 * 71;
 
     private IStrategoTerm head;
 
@@ -37,8 +30,8 @@ public abstract class SkeletonStrategoList extends StrategoTerm implements IStra
      *
      * @see #prepend(IStrategoTerm) Adds a new head element to a list.
      */
-    protected SkeletonStrategoList(IStrategoList annotations, int storageType) {
-        super(annotations, storageType);
+    protected SkeletonStrategoList(IStrategoList annotations) {
+        super(annotations);
     }
 
     @Deprecated
@@ -60,47 +53,38 @@ public abstract class SkeletonStrategoList extends StrategoTerm implements IStra
     }
 
     @Override
-    protected boolean doSlowMatch(IStrategoTerm second, int commonStorageType) {
-        if (second.getTermType() != IStrategoTerm.LIST)
+    protected boolean doSlowMatch(IStrategoTerm second) {
+        if(second.getTermType() != IStrategoTerm.LIST)
             return false;
 
         final IStrategoList snd = (IStrategoList) second;
-        if (size() != snd.size())
+        if(size() != snd.size())
             return false;
 
-        if (!isEmpty()) {
+        if(!isEmpty()) {
             IStrategoTerm head = head();
             IStrategoTerm head2 = snd.head();
-            if (head != head2 && !head.match(head2))
+            if(head != head2 && !head.match(head2))
                 return false;
 
             IStrategoList tail = tail();
             IStrategoList tail2 = snd.tail();
 
             // TODO: test equality of annos on cons nodes (see BasicStrategoList)
-            for (IStrategoList cons = tail, cons2 = tail2; !cons.isEmpty(); cons = cons.tail(), cons2 = cons2.tail()) {
+            for(IStrategoList cons = tail, cons2 = tail2; !cons.isEmpty(); cons = cons.tail(), cons2 = cons2.tail()) {
                 IStrategoTerm consHead = cons.head();
                 IStrategoTerm cons2Head = cons2.head();
-                if (consHead != cons2Head && !consHead.match(cons2Head))
+                if(consHead != cons2Head && !consHead.match(cons2Head))
                     return false;
-            }
-
-            if (commonStorageType == SHARABLE) {
-                this.head = head2;
-                this.tail = tail2;
             }
         }
 
         IStrategoList annotations = getAnnotations();
         IStrategoList secondAnnotations = second.getAnnotations();
-        if (annotations == secondAnnotations) {
+        if(annotations == secondAnnotations) {
             return true;
-        } else if (annotations.match(secondAnnotations)) {
-            if (commonStorageType == SHARABLE) internalSetAnnotations(secondAnnotations);
-            return true;
-        } else {
-            return false;
-        }
+        } else
+            return annotations.match(secondAnnotations);
     }
 
     public final void prettyPrint(ITermPrinter pp) {
@@ -110,7 +94,7 @@ public abstract class SkeletonStrategoList extends StrategoTerm implements IStra
     public final void writeAsString(Appendable output, int maxDepth) throws IOException {
         output.append('[');
         if(!isEmpty()) {
-            if (maxDepth == 0) {
+            if(maxDepth == 0) {
                 output.append("...");
             } else {
                 IStrategoTerm[] kids = getAllSubterms();
@@ -147,27 +131,26 @@ public abstract class SkeletonStrategoList extends StrategoTerm implements IStra
 
     @Override
     public final String toString(int maxDepth) {
-    	return super.toString(maxDepth);
+        return super.toString(maxDepth);
     }
-    
+
     @Override
-    public final <T extends ITermAttachment> T getAttachment(
-    		TermAttachmentType<T> type) {
-    	return super.getAttachment(type);
+    public final <T extends ITermAttachment> T getAttachment(TermAttachmentType<T> type) {
+        return super.getAttachment(type);
     }
-    
+
     @Override
     public final void putAttachment(ITermAttachment attachment) {
-    	super.putAttachment(attachment);
+        super.putAttachment(attachment);
     }
-    
+
     @Override
     public final ITermAttachment removeAttachment(TermAttachmentType<?> type) {
-    	return super.removeAttachment(type);
+        return super.removeAttachment(type);
     }
-    
+
     @Override
     protected final void clearAttachments() {
-    	super.clearAttachments();
+        super.clearAttachments();
     }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonTermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonTermFactory.java
@@ -12,12 +12,8 @@ import org.spoofax.terms.util.NotImplementedException;
 
 public abstract class SkeletonTermFactory extends AbstractTermFactory {
 
-    public SkeletonTermFactory(int defaultStorageType) {
-        super(defaultStorageType);
-    }
-
-    final public ITermFactory getFactoryWithStorageType(int storageType) {
-        throw new NotImplementedException();
+    public SkeletonTermFactory() {
+        super();
     }
 
     final public IStrategoPlaceholder makePlaceholder(IStrategoTerm template) {


### PR DESCRIPTION
This PR removes the storage types `MUTABLE`, `IMMUTABLE`, `SHARABLE`, `MAXIMALLY_SHARED`. Code paths that differed based on the storage type only kept the one for `MUTABLE` (to support attachments), except for the hashcode/equals which now always caches the hashcode and uses in the equals. The pull requests below make the necessary changes in all related Java code. 

https://github.com/metaborg/stratego/pull/7
https://github.com/metaborg/strategoxt/pull/30
https://github.com/metaborg/spoofax-eclipse/pull/15
https://github.com/metaborg/spoofax/pull/55
https://github.com/metaborg/spg/pull/2
https://github.com/metaborg/nabl/pull/24
https://github.com/metaborg/mb-rep/pull/12
https://github.com/metaborg/mb-exec/pull/5
https://github.com/metaborg/jsglr/pull/63
https://github.com/metaborg/flowspec/pull/3

Previous analysis leading up to this:

# Proposal for removal of storage type in the Java implementation of ATerms

ATerms as we use them in the Java runtime for Stratego are classes that implement the `IStrategoTerm` interface and the code base lives in the `mb-rep` sub-module/repository in the `org.spoofax.terms` package. While designing better interfaces for them in my free time, I noticed that the most messy and complicated code has to do with the storage type of terms. I believe we can simplify the existing code by removing the distinction in storage types. 

## Analysis of the meaning and usage of storage types

The class `IStrategoTerm` defines the following storage types:
 - `MUTABLE = 0`
 - `IMMUTABLE = 1`
 - `SHARABLE = 2`
 - `MAXIMALLY_SHARED = 3`

A tree of terms has the invariant that a parent term has the minimum of the storage type of its children and the default storage type of the factory.

From analysing the code/comments wherever these constants are used, I conclude that these mean the following:

  - `MAXIMALLY_SHARED` means that we only have one instance of any given term. 
    Terms with this storage type cache their hashcode and use it for fast inequality detection.  
    Equality is done through checking object identity.  
    Annotating a term with the factory will wrap the existing term to share the base value.  
    Maximal sharing is only used on the empty list singleton.  
    **The TermFactory implementation doesn't support maximal sharing.**
  - `SHARABLE` means that we try to improve sharing by mutating trees under the hood to share more during equality checking.  
    Terms with this storage type cache their hashcode and use it for fast inequality detection.  
    Any term that is compared and has the same annotation will start sharing annotations.  
    Any term with children will share the children array when found equal, or the children left of the not-equal child if the children a not all equal.  
    **This dynamic sharing code complicates equality matching and is actually dead code! It happens in `doSlowMatch` and uses the parameter `commonStorageType`, which is never equal to `SHARABLE` as the only places that call `doSlowMatch` (`match`) call it only with `IMMUTABLE` and `MUTABLE`.**
  - `IMMUTABLE` means that the tree is absolutely not mutated, even for sharing.  
    **This value is basically unused.**  
    Terms with this storage type cache their hashcode and use it for fast inequality detection.
  - `MUTABLE` means that terms may have attachments. It is also used for the StrategoMap (hashtable) and StrategoSet (iset) datastructures.  
    **Terms with this storage type do not cache their hashcode and equality is always the slow path!**  
    This is true, despite attachments not counting in term equality. (in fact, annotations are not even part of the hashcode)  
    You may think this is because of the mutable datastructures, but those use identity equality and Java's `System.identityHashcode`, so the hash code of a mutable tree is actually stable.  
    This storage type is used by the termfactory in the imploder of the parser so it can attach imploder attachments with the offsets/filename to locate ASTs in the file for notes/warning/errors. 
    This storage type is used by all termfactories in Spoofax to be able to track origins. 

## Proposal for removal

In conclusion: Maximal sharing is not supported. Sharing complicates code a lot and is currently dead code. Immutable trees are not used. Mutable trees are already the default. We can simplify the code by removing storage types and all the dead/complicated code related to it. While doing this, we can also improve the hashcode/equals methods to always cache the hashcode (requiring blobs/mutable datastructures that people add in to have a stable hashcode/equals). This should actually have a positive effect on Stratego execution speed. 

## Note on sharing

Michael Steindorfer has looked into the use of sharing in language engineering cases and mentioned that it isn't used in Rascal because of file/offset information making all leaves unique. Exploring the use of sharing in language engineering setting is a separate topic that may be explored from the angle of the incremental JSGLR implementation being developed by Maarten. It will likely have a solution that requires a tree implementation without any mutable attachments (e.g. using width information like red-green trees in the Roslyn C# compiler). This will pose challenges for transformations as well, and therefore I believe we don't need to save the dead code on sharing for that situation. 
