### PR TITLE
Improve memory usage of StrategoArrayList

### DIFF
--- a/org.spoofax.terms/src/org/spoofax/interpreter/terms/ISimpleTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/interpreter/terms/ISimpleTerm.java
@@ -37,26 +37,84 @@ public interface ISimpleTerm extends Serializable {
 	 * @param type the term attachment type, or {@code null} if the first attachment should be returned
      * @return the term attachment of the specified type; or {@code null} if it could not be found
 	 */
-    @Nullable <T extends ITermAttachment> T getAttachment(@Nullable TermAttachmentType<T> type);
+    @SuppressWarnings("unchecked")
+	default @Nullable <T extends ITermAttachment> T getAttachment(@Nullable TermAttachmentType<T> type) {
+		ITermAttachment attachment = internalGetAttachment();
+		if(type == null)
+			return (T) attachment;
+		for(ITermAttachment a = attachment; a != null; a = a.getNext()) {
+			if(a.getAttachmentType() == type)
+				return (T) a;
+		}
+		return null;
+	}
 
     // FIXME: Return a new term when adding/changing an attachment. Make the term immutable.
     /**
      * Adds the specified term attachment to this term.
      * If a term attachment of this type is already present, it is replaced.
      *
-     * @param resourceAttachment the attachment to add
+     * @param attachmentToPut the attachment to add
      */
-	void putAttachment(ITermAttachment resourceAttachment);
+	default void putAttachment(ITermAttachment attachmentToPut) {
+		ITermAttachment attachment = internalGetAttachment();
+		if(attachmentToPut == null)
+			return;
+		if(attachment == null) {
+			internalSetAttachment(attachmentToPut);
+		} else {
+			TermAttachmentType<?> newType = attachmentToPut.getAttachmentType();
+			if(attachment.getAttachmentType() == newType) {
+				attachmentToPut.setNext(attachment.getNext());
+				internalSetAttachment(attachmentToPut);
+			} else {
+				ITermAttachment previous = attachment;
+				for(ITermAttachment a = previous.getNext(); a != null; a = a.getNext()) {
+					if(a.getAttachmentType() == newType) {
+						attachmentToPut.setNext(a.getNext());
+						previous.setNext(attachmentToPut);
+						break;
+					}
+					previous = a;
+				}
+				previous.setNext(attachmentToPut);
+			}
+		}
+	}
 
     // FIXME: Return a new term when removing an attachment. Make the term immutable.
     /**
      * Removes the term attachment of the specified type,
      * if one is available for this term.
      *
-     * @param attachmentType the term attachment type
+     * @param type the term attachment type
      * @return the removed term attachment; or {@code null} when no attachment was removed
      */
-    @Nullable ITermAttachment removeAttachment(TermAttachmentType<?> attachmentType);
+    default @Nullable ITermAttachment removeAttachment(TermAttachmentType<?> type) {
+		ITermAttachment attachment = internalGetAttachment();
+		if(attachment != null) {
+			if(attachment.getAttachmentType() == type) {
+				internalSetAttachment(attachment.getNext());
+				attachment.setNext(null);
+				return attachment;
+			} else {
+				ITermAttachment previous = attachment;
+				for(ITermAttachment a = attachment.getNext(); a != null; a = a.getNext()) {
+					if(a.getAttachmentType() == type) {
+						previous.setNext(a.getNext());
+						a.setNext(null);
+						return a;
+					}
+					previous = a;
+				}
+			}
+		}
+		return null;
+	}
+
+    ITermAttachment internalGetAttachment();
+
+    void internalSetAttachment(ITermAttachment attachment);
 
     /**
      * Gets whether this term is a list term.

--- a/org.spoofax.terms/src/org/spoofax/interpreter/terms/IStrategoArrayList.java
+++ b/org.spoofax.terms/src/org/spoofax/interpreter/terms/IStrategoArrayList.java
@@ -1,0 +1,234 @@
+package org.spoofax.interpreter.terms;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.RandomAccess;
+import org.spoofax.terms.StrategoArrayList;
+import org.spoofax.terms.StrategoArrayListBuilder;
+import org.spoofax.terms.StrategoArrayListIterator;
+import org.spoofax.terms.StrategoArrayListTail;
+import org.spoofax.terms.StrategoList;
+import org.spoofax.terms.TermList;
+import org.spoofax.terms.util.TermUtils;
+
+import static org.spoofax.terms.AbstractTermFactory.EMPTY_TERM_ARRAY;
+
+/**
+ * Most of the shared implementation for {@link StrategoArrayList} and {@link StrategoArrayListTail}
+ */
+public interface IStrategoArrayList extends IStrategoTerm, IStrategoList, RandomAccess, InternalIStrategoArrayList {
+    static IStrategoArrayList fromCollection(Collection<? extends IStrategoTerm> terms) {
+        return new StrategoArrayList(terms.toArray(EMPTY_TERM_ARRAY));
+    }
+
+    static StrategoArrayListBuilder arrayListBuilder() {
+        return new StrategoArrayListBuilder(16);
+    }
+
+    static StrategoArrayListBuilder arrayListBuilder(int size) {
+        return new StrategoArrayListBuilder(size);
+    }
+
+    @Override
+    default boolean internalDoSlowMatch(IStrategoTerm second) {
+        if(this == second) {
+            return true;
+        }
+        if(!TermUtils.isList(second)) {
+            return false;
+        }
+        if(this.getSubtermCount() != second.getSubtermCount()) {
+            return false;
+        }
+
+        if(second instanceof StrategoArrayList) {
+            IStrategoArrayList other = (IStrategoArrayList) second;
+
+            if(!this.getAnnotations().match(other.getAnnotations())) {
+                return false;
+            }
+
+            //noinspection ArrayEquality
+            if(this.internalGetBackingArray() == other.internalGetBackingArray()) {
+                return internalGetOffset() == other.internalGetOffset() && this.internalGetEndOffset() == other.internalGetEndOffset();
+            }
+
+            Iterator<IStrategoTerm> termsThis = this.iterator();
+            Iterator<IStrategoTerm> termsOther = other.iterator();
+
+            if(!this.isEmpty()) {
+                for(IStrategoTerm thisNext = termsThis.next(), otherNext = termsOther.next()
+                    ; termsThis.hasNext()
+                        ; thisNext = termsThis.next(), otherNext = termsOther.next()) {
+                    if(thisNext != otherNext && !thisNext.match(otherNext)) {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        final IStrategoList snd = (IStrategoList) second;
+
+        if(!isEmpty()) {
+            IStrategoTerm head = head();
+            IStrategoTerm head2 = snd.head();
+            if(head != head2 && !head.match(head2))
+                return false;
+
+            IStrategoList tail = tail();
+            IStrategoList tail2 = snd.tail();
+
+            for(IStrategoList cons = tail, cons2 = tail2; !cons.isEmpty(); cons = cons.tail(), cons2 = cons2.tail()) {
+                IStrategoTerm consHead = cons.head();
+                IStrategoTerm cons2Head = cons2.head();
+                if(!cons.getAnnotations().match(cons2.getAnnotations())) {
+                    return false;
+                }
+                if(consHead != cons2Head && !consHead.match(cons2Head))
+                    return false;
+            }
+        }
+
+        IStrategoList annotations = getAnnotations();
+        IStrategoList secondAnnotations = second.getAnnotations();
+        if(annotations == secondAnnotations) {
+            return true;
+        } else
+            return annotations.match(secondAnnotations);
+    }
+
+    /**
+     * N.B. this implementation may look strange but it's designed to return the same hashcode as {@link StrategoList#hashFunction()}
+     */
+    @Override
+    default int internalHashFunction() {
+        if(isEmpty())
+            return 1;
+
+        int i = internalGetOffset();
+        int result = 31 * internalGetBackingArray()[i].hashCode();
+        for(i++; i < internalGetEndOffset(); i++) {
+            result = 31 * result + internalGetBackingArray()[i].hashCode();
+        }
+
+        return result;
+    }
+
+    @Override
+    default int getSubtermCount() {
+        return internalGetEndOffset() - internalGetOffset();
+    }
+
+    @Override
+    default IStrategoTerm getSubterm(int index) {
+        if(index < getSubtermCount()) {
+            return internalGetBackingArray()[internalGetOffset() + index];
+        } else {
+            throw new IndexOutOfBoundsException();
+        }
+    }
+
+    @Override
+    default IStrategoTerm[] getAllSubterms() {
+        return Arrays.copyOfRange(internalGetBackingArray(), internalGetOffset(), internalGetEndOffset());
+    }
+
+    @Override
+    default List<IStrategoTerm> getSubterms() {
+        return TermList.ofUnsafe(getAllSubterms());
+    }
+
+    @Override
+    default int getTermType() {
+        return IStrategoTerm.LIST;
+    }
+
+    @Deprecated @Override
+    default void prettyPrint(ITermPrinter pp) {
+        if(!isEmpty()) {
+            pp.println("[");
+            pp.indent(2);
+            Iterator<IStrategoTerm> iter = iterator();
+            iter.next().prettyPrint(pp);
+            while(iter.hasNext()) {
+                IStrategoTerm element = iter.next();
+                pp.print(",");
+                pp.nextIndentOff();
+                element.prettyPrint(pp);
+                pp.println("");
+            }
+            pp.println("");
+            pp.print("]");
+            pp.outdent(2);
+
+        } else {
+            pp.print("[]");
+        }
+        internalPrintAnnotations(pp);
+    }
+
+    @Override
+    default void writeAsString(Appendable output, int maxDepth) throws IOException {
+        output.append('[');
+        if(!isEmpty()) {
+            if(maxDepth == 0) {
+                output.append("...");
+            } else {
+                Iterator<IStrategoTerm> iter = iterator();
+                iter.next().writeAsString(output, maxDepth - 1);
+                while(iter.hasNext()) {
+                    IStrategoTerm element = iter.next();
+                    output.append(',');
+                    element.writeAsString(output, maxDepth - 1);
+                }
+            }
+        }
+        output.append(']');
+        internalAppendAnnotations(output, maxDepth);
+    }
+
+    @Deprecated @Override
+    default IStrategoTerm get(int index) {
+        return getSubterm(index);
+    }
+
+    @Deprecated @Override
+    default int size() {
+        return getSubtermCount();
+    }
+
+    @Deprecated @Override
+    default IStrategoList prepend(IStrategoTerm prefix) {
+        return new StrategoList(prefix, this, null);
+    }
+
+    @Override
+    default IStrategoTerm head() {
+        try {
+            return getSubterm(0);
+        } catch(IndexOutOfBoundsException e) {
+            throw new NoSuchElementException();
+        }
+    }
+
+    @Override
+    default boolean isEmpty() {
+        return getSubtermCount() == 0;
+    }
+
+    @Override
+    default Iterator<IStrategoTerm> iterator() {
+        return new StrategoArrayListIterator(this);
+    }
+
+    @Override
+    default boolean isList() {
+        return true;
+    }
+}

--- a/org.spoofax.terms/src/org/spoofax/interpreter/terms/InternalIStrategoArrayList.java
+++ b/org.spoofax.terms/src/org/spoofax/interpreter/terms/InternalIStrategoArrayList.java
@@ -1,0 +1,23 @@
+package org.spoofax.interpreter.terms;
+
+import java.io.IOException;
+import org.spoofax.terms.StrategoArrayList;
+
+/**
+ * Internal interface used to share code between the {@link StrategoArrayList} and {@link StrategoArrayListTail}
+ */
+interface InternalIStrategoArrayList {
+    IStrategoTerm[] internalGetBackingArray();
+
+    int internalGetOffset();
+
+    int internalGetEndOffset();
+
+    boolean internalDoSlowMatch(IStrategoTerm second);
+
+    int internalHashFunction();
+
+    void internalAppendAnnotations(Appendable output, int maxDepth) throws IOException;
+
+    void internalPrintAnnotations(ITermPrinter pp);
+}

--- a/org.spoofax.terms/src/org/spoofax/terms/AbstractSimpleTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/AbstractSimpleTerm.java
@@ -2,9 +2,6 @@ package org.spoofax.terms;
 
 import org.spoofax.interpreter.terms.ISimpleTerm;
 import org.spoofax.terms.attachments.ITermAttachment;
-import org.spoofax.terms.attachments.TermAttachmentType;
-
-import javax.annotation.Nullable;
 
 
 /**
@@ -16,73 +13,18 @@ public abstract class AbstractSimpleTerm implements ISimpleTerm, Cloneable {
 
     private ITermAttachment attachment;
 
-    @SuppressWarnings("unchecked")
-    @Override
-    @Nullable public <T extends ITermAttachment> T getAttachment(@Nullable TermAttachmentType<T> type) {
-        if(type == null)
-            return (T) this.attachment;
-        for(ITermAttachment a = this.attachment; a != null; a = a.getNext()) {
-            if(a.getAttachmentType() == type)
-                return (T) a;
-        }
-        return null;
+    protected void clearAttachments() {
+        attachment = null;
     }
 
     @Override
-    public void putAttachment(ITermAttachment attachment) {
-        if(attachment == null)
-            return;
-        if(this.attachment == null) {
-            this.attachment = attachment;
-        } else {
-            TermAttachmentType<?> newType = attachment.getAttachmentType();
-            if(this.attachment.getAttachmentType() == newType) {
-                attachment.setNext(this.attachment.getNext());
-                this.attachment = attachment;
-            } else {
-                ITermAttachment previous = this.attachment;
-                for(ITermAttachment a = previous.getNext(); a != null; a = a.getNext()) {
-                    if(a.getAttachmentType() == newType) {
-                        attachment.setNext(a.getNext());
-                        previous.setNext(attachment);
-                        break;
-                    }
-                    previous = a;
-                }
-                previous.setNext(attachment);
-            }
-        }
-    }
-
-    @Override
-    @Nullable public ITermAttachment removeAttachment(TermAttachmentType<?> type) {
-        if(attachment != null) {
-            if(attachment.getAttachmentType() == type) {
-                ITermAttachment old = attachment;
-                attachment = attachment.getNext();
-                old.setNext(null);
-                return old;
-            } else {
-                ITermAttachment previous = this.attachment;
-                for(ITermAttachment a = attachment.getNext(); a != null; a = a.getNext()) {
-                    if(a.getAttachmentType() == type) {
-                        previous.setNext(a.getNext());
-                        a.setNext(null);
-                        return a;
-                    }
-                    previous = a;
-                }
-            }
-        }
-        return null;
-    }
-
-    protected final ITermAttachment attachment() {
+    public ITermAttachment internalGetAttachment() {
         return attachment;
     }
 
-    protected void clearAttachments() {
-        attachment = null;
+    @Override
+    public void internalSetAttachment(ITermAttachment attachment) {
+        this.attachment = attachment;
     }
 
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/AbstractTermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/AbstractTermFactory.java
@@ -86,7 +86,7 @@ public abstract class AbstractTermFactory implements ITermFactory {
     }
 
     public IStrategoList makeList(Collection<? extends IStrategoTerm> terms) {
-        return StrategoArrayList.fromCollection(terms);
+        return IStrategoArrayList.fromCollection(terms);
     }
 
     public final IStrategoList makeListCons(IStrategoTerm head, IStrategoList tail) {
@@ -118,10 +118,10 @@ public abstract class AbstractTermFactory implements ITermFactory {
     }
 
     public IStrategoList.Builder arrayListBuilder() {
-        return StrategoArrayList.arrayListBuilder();
+        return IStrategoArrayList.arrayListBuilder();
     }
 
     public IStrategoList.Builder arrayListBuilder(int size) {
-        return StrategoArrayList.arrayListBuilder(size);
+        return IStrategoArrayList.arrayListBuilder(size);
     }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoArrayList.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoArrayList.java
@@ -1,289 +1,96 @@
 package org.spoofax.terms;
 
+import org.spoofax.interpreter.terms.IStrategoArrayList;
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermPrinter;
 import org.spoofax.terms.attachments.ITermAttachment;
-import org.spoofax.terms.attachments.TermAttachmentType;
-import org.spoofax.terms.util.TermUtils;
+
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.RandomAccess;
 
-import javax.annotation.Nullable;
-
-import static org.spoofax.terms.AbstractTermFactory.EMPTY_TERM_ARRAY;
-
-public class StrategoArrayList extends StrategoTerm implements IStrategoList, RandomAccess {
+/**
+ * @see IStrategoArrayList for most of the shared implementation for this class and {@link StrategoArrayListTail}
+ */
+public class StrategoArrayList extends StrategoTerm implements IStrategoArrayList {
     private static final long serialVersionUID = -1746012089187246512L;
 
-    final IStrategoTerm[] terms;
+    final IStrategoTerm[] backingArray;
     private final int offset;
     final int endOffset;
-    final ITermAttachment[] tailAttachments;
+    ITermAttachment[] tailAttachments;
 
-    public StrategoArrayList(IStrategoTerm... terms) {
-        this(terms, null);
+    public StrategoArrayList(IStrategoTerm... backingArray) {
+        this(backingArray, null);
     }
 
-    public StrategoArrayList(IStrategoTerm[] terms, IStrategoList annotations) {
-        this(terms, annotations, 0, terms.length, new ITermAttachment[terms.length]);
+    public StrategoArrayList(IStrategoTerm[] backingArray, IStrategoList annotations) {
+        this(backingArray, annotations, 0, backingArray.length);
     }
 
-    protected StrategoArrayList(IStrategoTerm[] terms, IStrategoList annotations, int offset, int endOffset) {
-        this(terms, annotations, offset, endOffset, new ITermAttachment[terms.length]);
-    }
-
-    protected StrategoArrayList(IStrategoTerm[] terms, IStrategoList annotations, int offset, int endOffset, ITermAttachment[] tailAttachments) {
+    protected StrategoArrayList(IStrategoTerm[] backingArray, IStrategoList annotations, int offset, int endOffset) {
         super(annotations);
-        if(offset > terms.length) {
+        if(offset > backingArray.length) {
             throw new IllegalArgumentException(
-                "Offset (" + offset + ") is larger than backing array (" + terms.length + ")");
+                "Offset (" + offset + ") is larger than backing array (" + backingArray.length + ")");
         }
-        if(endOffset > terms.length) {
+        if(endOffset > backingArray.length) {
             throw new IllegalArgumentException(
-                "Length (" + endOffset + ") is larger than backing array (" + terms.length + ")");
+                "Length (" + endOffset + ") is larger than backing array (" + backingArray.length + ")");
         }
-        this.terms = terms;
+        this.backingArray = backingArray;
         this.offset = offset;
         this.endOffset = endOffset;
-        this.tailAttachments = tailAttachments;
-        if(offset > 0) {
-            final ITermAttachment attachment = tailAttachments[offset-1];
-            if(attachment != null) {
-                super.putAttachment(attachment);
-            }
-        }
-    }
-
-    public static StrategoArrayList fromCollection(Collection<? extends IStrategoTerm> terms) {
-        return new StrategoArrayList(terms.toArray(EMPTY_TERM_ARRAY));
-    }
-
-    public static StrategoArrayListBuilder arrayListBuilder() {
-        return new StrategoArrayListBuilder(16);
-    }
-
-    public static StrategoArrayListBuilder arrayListBuilder(int size) {
-        return new StrategoArrayListBuilder(size);
-    }
-
-    @Override public int getSubtermCount() {
-        return endOffset - offset;
-    }
-
-    @Override public IStrategoTerm getSubterm(int index) {
-        if(index < getSubtermCount()) {
-            return terms[offset + index];
-        } else {
-            throw new IndexOutOfBoundsException();
-        }
+        this.tailAttachments = null;
     }
 
     @Override
-    public IStrategoTerm[] getAllSubterms() {
-        return Arrays.copyOfRange(terms, offset, endOffset);
+    public IStrategoTerm[] internalGetBackingArray() {
+        return backingArray;
     }
 
     @Override
-    public List<IStrategoTerm> getSubterms() {
-        return TermList.ofUnsafe(getAllSubterms());
+    public int internalGetOffset() {
+        return offset;
     }
 
-    @Override public int getTermType() {
-        return IStrategoTerm.LIST;
+    @Override
+    public int internalGetEndOffset() {
+        return endOffset;
     }
 
-    @Deprecated @Override public void prettyPrint(ITermPrinter pp) {
-        if(!isEmpty()) {
-            pp.println("[");
-            pp.indent(2);
-            Iterator<IStrategoTerm> iter = iterator();
-            iter.next().prettyPrint(pp);
-            while(iter.hasNext()) {
-                IStrategoTerm element = iter.next();
-                pp.print(",");
-                pp.nextIndentOff();
-                element.prettyPrint(pp);
-                pp.println("");
-            }
-            pp.println("");
-            pp.print("]");
-            pp.outdent(2);
-
-        } else {
-            pp.print("[]");
+    ITermAttachment[] internalGetTailAttachments() {
+        if(tailAttachments == null) {
+            tailAttachments = new ITermAttachment[getSubtermCount()];
         }
-        printAnnotations(pp);
+        return tailAttachments;
     }
 
-    @Override public void writeAsString(Appendable output, int maxDepth) throws IOException {
-        output.append('[');
-        if(!isEmpty()) {
-            if(maxDepth == 0) {
-                output.append("...");
-            } else {
-                Iterator<IStrategoTerm> iter = iterator();
-                iter.next().writeAsString(output, maxDepth - 1);
-                while(iter.hasNext()) {
-                    IStrategoTerm element = iter.next();
-                    output.append(',');
-                    element.writeAsString(output, maxDepth - 1);
-                }
-            }
-        }
-        output.append(']');
+    @Override
+    public void internalAppendAnnotations(Appendable output, int maxDepth) throws IOException {
         appendAnnotations(output, maxDepth);
     }
 
-    @Deprecated @Override public IStrategoTerm get(int index) {
-        return getSubterm(index);
+    @SuppressWarnings("deprecation")
+    @Override
+    public void internalPrintAnnotations(ITermPrinter pp) {
+        printAnnotations(pp);
     }
 
-    @Deprecated @Override public int size() {
-        return getSubtermCount();
+    @Override
+    protected boolean doSlowMatch(IStrategoTerm second) {
+        return internalDoSlowMatch(second);
     }
 
-    @Deprecated @Override public IStrategoList prepend(IStrategoTerm prefix) {
-        return new StrategoList(prefix, this, null);
+    @Override
+    protected int hashFunction() {
+        return internalHashFunction();
     }
 
-    @Override public IStrategoTerm head() {
-        try {
-            return getSubterm(0);
-        } catch(IndexOutOfBoundsException e) {
-            throw new NoSuchElementException();
-        }
-    }
-
-    @Override public IStrategoList tail() {
+    @Override
+    public IStrategoList tail() {
         if(isEmpty()) {
             throw new IllegalStateException();
         }
-        return new StrategoArrayList(terms, null, offset + 1, endOffset, tailAttachments);
+        return new StrategoArrayListTail(this, offset + 1);
     }
-
-    @Override public boolean isEmpty() {
-        return getSubtermCount() == 0;
-    }
-
-    @Override protected boolean doSlowMatch(IStrategoTerm second) {
-        if(this == second) {
-            return true;
-        }
-        if(!TermUtils.isList(second)) {
-            return false;
-        }
-        if(this.getSubtermCount() != second.getSubtermCount()) {
-            return false;
-        }
-
-        if(second instanceof StrategoArrayList) {
-            StrategoArrayList other = (StrategoArrayList) second;
-
-            if(!this.getAnnotations().match(other.getAnnotations())) {
-                return false;
-            }
-
-            //noinspection ArrayEquality
-            if(this.terms == other.terms) {
-                return offset == other.offset && this.endOffset == other.endOffset;
-            }
-
-            Iterator<IStrategoTerm> termsThis = this.iterator();
-            Iterator<IStrategoTerm> termsOther = other.iterator();
-
-            if(!this.isEmpty()) {
-                for(IStrategoTerm thisNext = termsThis.next(), otherNext = termsOther.next()
-                   ; termsThis.hasNext()
-                   ; thisNext = termsThis.next(), otherNext = termsOther.next()) {
-                    if(thisNext != otherNext && !thisNext.match(otherNext)) {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
-        }
-
-        final IStrategoList snd = (IStrategoList) second;
-
-        if(!isEmpty()) {
-            IStrategoTerm head = head();
-            IStrategoTerm head2 = snd.head();
-            if(head != head2 && !head.match(head2))
-                return false;
-
-            IStrategoList tail = tail();
-            IStrategoList tail2 = snd.tail();
-
-            for(IStrategoList cons = tail, cons2 = tail2; !cons.isEmpty(); cons = cons.tail(), cons2 = cons2.tail()) {
-                IStrategoTerm consHead = cons.head();
-                IStrategoTerm cons2Head = cons2.head();
-                if(!cons.getAnnotations().match(cons2.getAnnotations())) {
-                    return false;
-                }
-                if(consHead != cons2Head && !consHead.match(cons2Head))
-                    return false;
-            }
-        }
-
-        IStrategoList annotations = getAnnotations();
-        IStrategoList secondAnnotations = second.getAnnotations();
-        if(annotations == secondAnnotations) {
-            return true;
-        } else
-            return annotations.match(secondAnnotations);
-    }
-
-    /**
-     * N.B. this implementation may look strange but it's designed to return the same hashcode as {@link StrategoList#hashFunction()}
-     */
-    @Override protected int hashFunction() {
-        if(isEmpty())
-            return 1;
-
-        int i = offset;
-        int result = 31 * terms[i].hashCode();
-        for(i++; i < endOffset; i++) {
-            result = 31 * result + terms[i].hashCode();
-        }
-
-        return result;
-    }
-
-    @Override public Iterator<IStrategoTerm> iterator() {
-        return new StrategoArrayListIterator(this);
-    }
-
-    @Override
-    public void putAttachment(ITermAttachment attachment) {
-        setTailAttachment(attachment);
-        super.putAttachment(attachment);
-    }
-
-    @Override
-    @Nullable
-    public ITermAttachment removeAttachment(TermAttachmentType<?> type) {
-        final ITermAttachment attachment = super.removeAttachment(type);
-        setTailAttachment(attachment());
-        return attachment;
-    }
-
-    @Override
-    protected void clearAttachments() {
-        setTailAttachment(null);
-        super.clearAttachments();
-    }
-
-    private void setTailAttachment(ITermAttachment attachment) {
-        if(offset > 0) {
-            tailAttachments[offset -1] = attachment;
-        }
-    }
-
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoArrayListIterator.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoArrayListIterator.java
@@ -2,13 +2,14 @@ package org.spoofax.terms;
 
 import java.util.Iterator;
 
+import org.spoofax.interpreter.terms.IStrategoArrayList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 
-final class StrategoArrayListIterator implements Iterator<IStrategoTerm> {
-    private final StrategoArrayList strategoArrayList;
+public final class StrategoArrayListIterator implements Iterator<IStrategoTerm> {
+    private final IStrategoArrayList strategoArrayList;
     private int position;
 
-    StrategoArrayListIterator(StrategoArrayList strategoArrayList) {
+    public StrategoArrayListIterator(IStrategoArrayList strategoArrayList) {
         this.strategoArrayList = strategoArrayList;
         this.position = 0;
     }

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoArrayListTail.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoArrayListTail.java
@@ -1,0 +1,89 @@
+package org.spoofax.terms;
+
+import java.io.IOException;
+import org.spoofax.interpreter.terms.IStrategoArrayList;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.terms.attachments.ITermAttachment;
+
+public class StrategoArrayListTail implements IStrategoArrayList {
+    private final StrategoArrayList original;
+    private final int offset;
+
+    public StrategoArrayListTail(StrategoArrayList original, int offset) {
+        this.original = original;
+        this.offset = offset;
+    }
+
+    @Override
+    public IStrategoTerm[] internalGetBackingArray() {
+        return original.internalGetBackingArray();
+    }
+
+    @Override
+    public int internalGetOffset() {
+        return offset;
+    }
+
+    @Override
+    public int internalGetEndOffset() {
+        return original.internalGetEndOffset();
+    }
+
+    @Override
+    public void internalAppendAnnotations(Appendable output, int maxDepth) {
+        // do nothing, these tails don't have annotations
+    }
+
+    @Override
+    public void internalPrintAnnotations(ITermPrinter pp) {
+        // do nothing, these tails don't have annotations
+    }
+
+    @Override
+    public IStrategoList getAnnotations() {
+        return new StrategoList(null);
+    }
+
+    // This is a copy of StrategoTerm#match
+    @Override
+    public boolean match(IStrategoTerm second) {
+        if(this == second)
+            return true;
+        if(second == null)
+            return false;
+
+        return hashCode() == second.hashCode() && internalDoSlowMatch(second);
+    }
+
+    // This is a copy of StrategoTerm#toString
+    @Override
+    public String toString(int maxDepth) {
+        StringBuilder result = new StringBuilder();
+        try {
+            writeAsString(result, maxDepth);
+        } catch(IOException e) {
+            throw new RuntimeException(e); // shan't happen
+        }
+        return result.toString();
+    }
+
+    @Override
+    public ITermAttachment internalGetAttachment() {
+        return original.internalGetTailAttachments()[offset - original.internalGetOffset()];
+    }
+
+    @Override
+    public void internalSetAttachment(ITermAttachment attachment) {
+        original.internalGetTailAttachments()[offset - original.internalGetOffset()] = attachment;
+    }
+
+    @Override
+    public IStrategoList tail() {
+        if(isEmpty()) {
+            throw new IllegalStateException();
+        }
+        return new StrategoArrayListTail(original, offset + 1);
+    }
+}

--- a/org.spoofax.terms/src/org/spoofax/terms/util/B.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/util/B.java
@@ -1,6 +1,8 @@
 package org.spoofax.terms.util;
 
+import java.util.Collection;
 import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoArrayList;
 import org.spoofax.interpreter.terms.IStrategoConstructor;
 import org.spoofax.interpreter.terms.IStrategoInt;
 import org.spoofax.interpreter.terms.IStrategoList;
@@ -13,7 +15,6 @@ import org.spoofax.terms.StrategoArrayList;
 import org.spoofax.terms.StrategoInt;
 import org.spoofax.terms.StrategoString;
 import org.spoofax.terms.StrategoTuple;
-import java.util.Collection;
 
 /**
  * A Stratego Term building class. The static methods can build anything but stratego application constructors.
@@ -53,7 +54,7 @@ public class B {
     }
 
     public static IStrategoList list(Collection<? extends IStrategoTerm> terms) {
-        return StrategoArrayList.fromCollection(terms);
+        return IStrategoArrayList.fromCollection(terms);
     }
 
     public static IStrategoList list(IStrategoList.Builder builder) {
@@ -61,11 +62,11 @@ public class B {
     }
 
     public static IStrategoList.Builder listBuilder(int size) {
-        return StrategoArrayList.arrayListBuilder(size);
+        return IStrategoArrayList.arrayListBuilder(size);
     }
 
     public static IStrategoList.Builder listBuilder() {
-        return StrategoArrayList.arrayListBuilder();
+        return IStrategoArrayList.arrayListBuilder();
     }
 
     public IStrategoAppl applShared(String cons, IStrategoTerm... children) {

--- a/org.spoofax.terms/test/org/spoofax/DummySimpleTerm.java
+++ b/org.spoofax.terms/test/org/spoofax/DummySimpleTerm.java
@@ -2,7 +2,6 @@ package org.spoofax;
 
 import org.spoofax.interpreter.terms.ISimpleTerm;
 import org.spoofax.terms.attachments.ITermAttachment;
-import org.spoofax.terms.attachments.TermAttachmentType;
 
 
 /**
@@ -21,16 +20,13 @@ public class DummySimpleTerm implements ISimpleTerm {
     }
 
     @Override
-    public <T extends ITermAttachment> T getAttachment(TermAttachmentType<T> type) {
+    public ITermAttachment internalGetAttachment() {
         return null;
     }
 
     @Override
-    public void putAttachment(ITermAttachment resourceAttachment) { /* Ignored */ }
+    public void internalSetAttachment(ITermAttachment attachment) {
 
-    @Override
-    public ITermAttachment removeAttachment(TermAttachmentType<?> attachmentType) {
-        return null;
     }
 
     @Override

--- a/org.spoofax.terms/test/org/spoofax/terms/StrategoArrayListTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/StrategoArrayListTests.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.spoofax.DummyStrategoTerm;
 import org.spoofax.TestUtils;
 import org.spoofax.interpreter.terms.ISimpleTermTests;
+import org.spoofax.interpreter.terms.IStrategoArrayList;
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoListTests;
 import org.spoofax.interpreter.terms.IStrategoTerm;
@@ -27,26 +28,26 @@ public class StrategoArrayListTests {
     public interface Fixture extends IStrategoListTests.Fixture {
 
         @Override
-        StrategoArrayList createIStrategoList(@Nullable List<IStrategoTerm> elements, @Nullable IStrategoList annotations,
-            @Nullable List<ITermAttachment> attachments);
+        IStrategoArrayList createIStrategoList(@Nullable List<IStrategoTerm> elements, @Nullable IStrategoList annotations,
+                                               @Nullable List<ITermAttachment> attachments);
 
         @Override
         StrategoList createConsNilIStrategoList(@Nullable IStrategoTerm head, @Nullable IStrategoList tail,
             @Nullable IStrategoList annotations, @Nullable List<ITermAttachment> attachments);
 
         @Override
-        StrategoArrayList createEmptyIStrategoList(@Nullable IStrategoList annotations,
-            @Nullable List<ITermAttachment> attachments);
+        IStrategoArrayList createEmptyIStrategoList(@Nullable IStrategoList annotations,
+                                                    @Nullable List<ITermAttachment> attachments);
 
     }
 
 
-    public static class FixtureImpl extends StrategoTermTests.FixtureImpl implements Fixture {
+    public static class FixtureImpl implements Fixture, StrategoTermTests.Fixture {
 
         @Override
-        public StrategoArrayList createIStrategoList(@Nullable List<IStrategoTerm> elements,
-                                                @Nullable IStrategoList annotations,
-                                                @Nullable List<ITermAttachment> attachments) {
+        public IStrategoArrayList createIStrategoList(@Nullable List<IStrategoTerm> elements,
+                                                      @Nullable IStrategoList annotations,
+                                                      @Nullable List<ITermAttachment> attachments) {
             if (elements == null || elements.isEmpty()) {
                 return createEmptyIStrategoList(annotations, attachments);
             }
@@ -65,15 +66,15 @@ public class StrategoArrayListTests {
         }
 
         @Override
-        public StrategoArrayList createEmptyIStrategoList(@Nullable IStrategoList annotations,
-                                                     @Nullable List<ITermAttachment> attachments) {
+        public IStrategoArrayList createEmptyIStrategoList(@Nullable IStrategoList annotations,
+                                                           @Nullable List<ITermAttachment> attachments) {
             return TestUtils.putAttachments(new StrategoArrayList(new IStrategoTerm[0],
                     annotations != null ? annotations : TermFactory.EMPTY_LIST
             ), attachments);
         }
 
         @Override
-        public StrategoTerm createIStrategoTerm(@Nullable List<IStrategoTerm> subterms,
+        public IStrategoTerm createIStrategoTerm(@Nullable List<IStrategoTerm> subterms,
                                                 @Nullable IStrategoList annotations,
                                                 @Nullable List<ITermAttachment> attachments) {
             if (subterms == null || subterms.isEmpty()) {
@@ -115,7 +116,7 @@ public class StrategoArrayListTests {
     @DisplayName("builder with extra capacity makes correct size list")
     void builderWithExtraCapaxity_makesCorrectSizeList() {
         // Arrange
-        IStrategoList.Builder b = StrategoArrayList.arrayListBuilder(10);
+        IStrategoList.Builder b = IStrategoArrayList.arrayListBuilder(10);
         b.add(new DummyStrategoTerm());
         b.add(new DummyStrategoTerm());
         b.add(new DummyStrategoTerm());
@@ -132,7 +133,7 @@ public class StrategoArrayListTests {
     @DisplayName("builder with extra capacity makes list with correct size tails")
     void builderWithExtraCapaxity_makesListWithCorrectSizeTails() {
         // Arrange
-        IStrategoList.Builder b = StrategoArrayList.arrayListBuilder(10);
+        IStrategoList.Builder b = IStrategoArrayList.arrayListBuilder(10);
         b.add(new DummyStrategoTerm());
         b.add(new DummyStrategoTerm());
         b.add(new DummyStrategoTerm());

--- a/org.spoofax.terms/test/org/spoofax/terms/StrategoTermTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/StrategoTermTests.java
@@ -22,7 +22,7 @@ public abstract class StrategoTermTests {
     public interface Fixture extends IStrategoTermTests.Fixture {
 
         @Override
-        StrategoTerm createIStrategoTerm(@Nullable List<IStrategoTerm> subterms,
+        IStrategoTerm createIStrategoTerm(@Nullable List<IStrategoTerm> subterms,
                                          @Nullable IStrategoList annotations,
                                          @Nullable List<ITermAttachment> attachments);
 


### PR DESCRIPTION
The `StrategoArrayList` is already available to more cheaply make `IStrategoList`s in Java. These lists already had tails which are simply views on the same array, without annotations. I thought this was enough at first, but then realised that despite this simple design, list tails may still receive attachments through mutation. Currently there is therefore an array of `ITermAttachment` in every `StrategoArrayList`. However, while necessary for completeness, these are probably not used a lot. 

This PR introduces a separate class `StrategoArrayListTail`. This object that uses less memory, and allows lazy initialization of tail attachments array in the `StrategoArrayList`. 

The reason I'm creating a PR is: To share code between the classes, I had to create some methods in interfaces that expose internals of classes. These methods start with `internal`, as was already used in `StrategoTerm#internalSetAnnotations`. Still, it's not very pretty. If you think this is not worth it, or if there's a better way, I'd love to hear about it.