### PR TITLE
Replace C-style term type integer checks with TermType enum

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,3 @@
+#!groovy
+@Library('metaborg.jenkins.pipeline') _
+spoofax2TriggerPipeline()

--- a/org.spoofax.terms/src/org/spoofax/interpreter/terms/ISimpleTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/interpreter/terms/ISimpleTerm.java
@@ -63,7 +63,7 @@ public interface ISimpleTerm extends Serializable {
      *
      * @return {@code true} when this term is a list term;
      * otherwise, {@code false}.
-     * @deprecated Use {@link IStrategoTerm#getTermType()} instead.
+     * @deprecated Use {@link IStrategoTerm#getType()} instead.
      */
 	@Deprecated
 	boolean isList();

--- a/org.spoofax.terms/src/org/spoofax/interpreter/terms/IStrategoTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/interpreter/terms/IStrategoTerm.java
@@ -12,7 +12,6 @@ import org.spoofax.terms.util.TermUtils;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.Writer;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 

--- a/org.spoofax.terms/src/org/spoofax/interpreter/terms/IStrategoTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/interpreter/terms/IStrategoTerm.java
@@ -118,8 +118,7 @@ public interface IStrategoTerm extends ISimpleTerm, Serializable, Iterable<IStra
     /**
      * Gets the type of term.
      *
-     * @return an integer value, one of: {@link #APPL}, {@link #LIST}, {@link #INT}, {@link #REAL},
-     * {@link #STRING}, {@link #CTOR}, {@link #TUPLE}, {@link #REF}, or {@link #BLOB}.
+     * @return an integer value, the value of {@link TermType#getValue()}
      * @deprecated Use {@link #getType()} instead.
      */
     @Deprecated

--- a/org.spoofax.terms/src/org/spoofax/interpreter/terms/IStrategoTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/interpreter/terms/IStrategoTerm.java
@@ -26,25 +26,65 @@ import java.util.List;
  */
 public interface IStrategoTerm extends ISimpleTerm, Serializable, Iterable<IStrategoTerm> {
 
-    /** A Constructor Application term type. */
+    /**
+     * A Constructor Application term type.
+     * @deprecated Use {@link TermType} instead.
+     */
+    @Deprecated
     int APPL = 1;
-    /** A List term type. */
+    /**
+     * A List term type.
+     * @deprecated Use {@link TermType} instead.
+     */
+    @Deprecated
     int LIST = 2;
-    /** An Int term type. */
+    /**
+     * An Int term type.
+     * @deprecated Use {@link TermType} instead.
+     */
+    @Deprecated
     int INT = 3;
-    /** A Real term type. */
+    /**
+     * A Real term type.
+     * @deprecated Use {@link TermType} instead.
+     */
+    @Deprecated
     int REAL = 4;
-    /** A String term type. */
+    /**
+     * A String term type.
+     * @deprecated Use {@link TermType} instead.
+     */
+    @Deprecated
     int STRING = 5;
-    /** A Term Constructor term type. */
+    /**
+     * A Term Constructor term type.
+     * @deprecated Use {@link TermType} instead.
+     */
+    @Deprecated
     int CTOR = 6;
-    /** A Tuple term type. */
+    /**
+     * A Tuple term type.
+     * @deprecated Use {@link TermType} instead.
+     */
+    @Deprecated
     int TUPLE = 7;
-    /** A Ref term type. */
+    /**
+     * A Ref term type.
+     * @deprecated Use {@link TermType} instead.
+     */
+    @Deprecated
     int REF = 8;
-    /** A Blob term type. */
+    /**
+     * A Blob term type.
+     * @deprecated Use {@link TermType} instead.
+     */
+    @Deprecated
     int BLOB = 9;
-    /** A Placeholder term type. */
+    /**
+     * A Placeholder term type.
+     * @deprecated Use {@link TermType} instead.
+     */
+    @Deprecated
     int PLACEHOLDER = 10;
 
     /** @deprecated Use {@link Integer#MAX_VALUE} instead. */
@@ -80,8 +120,17 @@ public interface IStrategoTerm extends ISimpleTerm, Serializable, Iterable<IStra
      *
      * @return an integer value, one of: {@link #APPL}, {@link #LIST}, {@link #INT}, {@link #REAL},
      * {@link #STRING}, {@link #CTOR}, {@link #TUPLE}, {@link #REF}, or {@link #BLOB}.
+     * @deprecated Use {@link #getType()} instead.
      */
+    @Deprecated
     int getTermType();
+
+    /**
+     * Gets the type of term.
+     *
+     * @return a member of the {@link TermType} enum.
+     */
+    TermType getType();
 
     /**
      * Gets the annnotations on this term.

--- a/org.spoofax.terms/src/org/spoofax/interpreter/terms/TermConverter.java
+++ b/org.spoofax.terms/src/org/spoofax/interpreter/terms/TermConverter.java
@@ -1,14 +1,5 @@
 package org.spoofax.interpreter.terms;
 
-import static org.spoofax.interpreter.terms.IStrategoTerm.APPL;
-import static org.spoofax.interpreter.terms.IStrategoTerm.BLOB;
-import static org.spoofax.interpreter.terms.IStrategoTerm.CTOR;
-import static org.spoofax.interpreter.terms.IStrategoTerm.INT;
-import static org.spoofax.interpreter.terms.IStrategoTerm.LIST;
-import static org.spoofax.interpreter.terms.IStrategoTerm.REAL;
-import static org.spoofax.interpreter.terms.IStrategoTerm.STRING;
-import static org.spoofax.interpreter.terms.IStrategoTerm.TUPLE;
-
 import java.util.HashMap;
 
 import org.spoofax.terms.StrategoAnnotation;
@@ -53,7 +44,7 @@ public class TermConverter {
     
     public IStrategoTerm convert(IStrategoTerm term) {
     	IStrategoTerm result;
-        switch (term.getTermType()) {
+        switch (term.getType()) {
             // APPL and LIST are inlined to help stack usage
             case APPL:
                 IStrategoAppl appl = (IStrategoAppl) term;
@@ -87,7 +78,7 @@ public class TermConverter {
     }
     
     public IStrategoTerm convertShallow(IStrategoTerm term, IStrategoTerm[] kids, IStrategoList annos) {
-		switch (term.getTermType()) {
+		switch (term.getType()) {
 			case APPL:
 				IStrategoConstructor cons = ((IStrategoAppl)term).getConstructor();
 				return factory.makeAppl(cons, kids, annos);

--- a/org.spoofax.terms/src/org/spoofax/interpreter/terms/TermType.java
+++ b/org.spoofax.terms/src/org/spoofax/interpreter/terms/TermType.java
@@ -1,0 +1,72 @@
+package org.spoofax.interpreter.terms;
+
+/**
+ * Specifies the type of a term.
+ *
+ * Enums can safely be compared using {@code ==}, with the additional
+ * benefit that the comparison will be false when either side evaluates to {@code null}.
+ */
+public enum TermType {
+    /** A Constructor Application term type. */
+    APPL(1),
+    /** A List term type. */
+    LIST(2),
+    /** An Int term type. */
+    INT(3),
+    /** A Real term type. */
+    REAL(4),
+    /** A String term type. */
+    STRING(5),
+    /** A Term Constructor term type. */
+    CTOR(6),
+    /** A Tuple term type. */
+    TUPLE(7),
+    /** A Ref term type. */
+    REF(8),
+    /** A Blob term type. */
+    BLOB(9),
+    /** A Placeholder term type. */
+    PLACEHOLDER(10);
+
+    @Deprecated
+    private final int value;
+
+    TermType(int value) {
+        this.value = value;
+    }
+
+    /**
+     * Gets the integer value, used for legacy code.
+     *
+     * @deprecated Compare the enum directly.
+     */
+    @Deprecated
+    public int getValue() {
+        return this.value;
+    }
+
+    /**
+     * Returns the {@link TermType} that corresponds to the given integer constant value.
+     * @param value the value
+     * @return the corresponding {@link TermType}
+     * @throws IllegalArgumentException The given value does not represent a valid term type.
+     * @deprecated Use {@link TermType} instead.
+     */
+    @Deprecated
+    public static TermType fromValue(int value) {
+        switch (value) {
+            case 1: return APPL;
+            case 2: return LIST;
+            case 3: return INT;
+            case 4: return REAL;
+            case 5: return STRING;
+            case 6: return CTOR;
+            case 7: return TUPLE;
+            case 8: return REF;
+            case 9: return BLOB;
+            case 10: return PLACEHOLDER;
+            default:
+                throw new IllegalArgumentException("The value " + value + " does not represent a valid term type.");
+        }
+    }
+}

--- a/org.spoofax.terms/src/org/spoofax/terms/AbstractStrategoList.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/AbstractStrategoList.java
@@ -6,11 +6,17 @@ import java.util.List;
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 import org.spoofax.terms.util.TermUtils;
 
 public abstract class AbstractStrategoList extends StrategoTerm implements IStrategoList {
     public AbstractStrategoList(IStrategoList annotations) {
         super(annotations);
+    }
+
+    @Override
+    public TermType getType() {
+        return TermType.LIST;
     }
 
     @Override

--- a/org.spoofax.terms/src/org/spoofax/terms/AbstractTermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/AbstractTermFactory.java
@@ -3,7 +3,12 @@ package org.spoofax.terms;
 import java.util.Collection;
 import java.util.HashMap;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoConstructor;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.IStrategoTuple;
+import org.spoofax.interpreter.terms.ITermFactory;
 import org.spoofax.terms.attachments.ITermAttachment;
 import org.spoofax.terms.io.TAFTermReader;
 

--- a/org.spoofax.terms/src/org/spoofax/terms/LazyTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/LazyTerm.java
@@ -4,16 +4,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
-import org.spoofax.interpreter.terms.IStrategoAppl;
-import org.spoofax.interpreter.terms.IStrategoConstructor;
-import org.spoofax.interpreter.terms.IStrategoInt;
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoNamed;
-import org.spoofax.interpreter.terms.IStrategoReal;
-import org.spoofax.interpreter.terms.IStrategoString;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.IStrategoTuple;
-import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.*;
 import org.spoofax.terms.attachments.ITermAttachment;
 import org.spoofax.terms.attachments.TermAttachmentType;
 import org.spoofax.terms.util.TermUtils;
@@ -66,9 +57,15 @@ public abstract class LazyTerm implements IStrategoAppl, IStrategoInt, IStratego
 		return getWrapped().getSubtermCount();
 	}
 
+	@Deprecated
 	@Override
 	public int getTermType() {
 		return getWrapped().getTermType();
+	}
+
+	@Override
+	public TermType getType() {
+		return getWrapped().getType();
 	}
 
 	@Deprecated

--- a/org.spoofax.terms/src/org/spoofax/terms/LazyTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/LazyTerm.java
@@ -60,7 +60,7 @@ public abstract class LazyTerm implements IStrategoAppl, IStrategoInt, IStratego
 	@Deprecated
 	@Override
 	public int getTermType() {
-		return getWrapped().getTermType();
+		return getType().getValue();
 	}
 
 	@Override
@@ -114,21 +114,21 @@ public abstract class LazyTerm implements IStrategoAppl, IStrategoInt, IStratego
 
 	@Override
 	public IStrategoTerm head() {
-		if(getTermType() != LIST)
+		if(getType() != TermType.LIST)
 			throw new TermWrapperException("Called head() on a term that is not of type LIST");
 		return ((IStrategoList) getWrapped()).head();
 	}
 
 	@Override
 	public IStrategoList tail() {
-		if(getTermType() != LIST)
+		if(getType() != TermType.LIST)
 			throw new TermWrapperException("Called tail() on a term that is not of type LIST");
 		return ((IStrategoList) getWrapped()).tail();
 	}
 
 	@Override
 	public boolean isEmpty() {
-		if(getTermType() != LIST)
+		if(getType() != TermType.LIST)
 			throw new TermWrapperException("Called isEmpty() on a term that is not of type LIST");
 		return ((IStrategoList) getWrapped()).isEmpty();
 	}
@@ -136,14 +136,14 @@ public abstract class LazyTerm implements IStrategoAppl, IStrategoInt, IStratego
 	@Deprecated
 	@Override
 	public IStrategoList prepend(IStrategoTerm prefix) {
-		if(getTermType() != LIST)
+		if(getType() != TermType.LIST)
 			throw new TermWrapperException("Called prepend() on a term that is not of type LIST");
 		return ((IStrategoList) getWrapped()).prepend(prefix);
 	}
 
 	@Override
 	public int size() {
-		switch(getTermType()) {
+		switch(getType()) {
 			case LIST:
 				return ((IStrategoList) getWrapped()).size();
 			case TUPLE:
@@ -155,21 +155,21 @@ public abstract class LazyTerm implements IStrategoAppl, IStrategoInt, IStratego
 
 	@Override
 	public IStrategoConstructor getConstructor() {
-		if(getTermType() != APPL)
+		if(getType() != TermType.APPL)
 			throw new TermWrapperException("Called getConstructor() on a term that is not of type APPL");
 		return ((IStrategoAppl) getWrapped()).getConstructor();
 	}
 
 	@Override
 	public String getName() {
-		if(getTermType() != STRING && getTermType() != APPL)
+		if(getType() != TermType.STRING && getType() != TermType.APPL)
 			throw new TermWrapperException("Called getName() on a term that is not of type STRING or APPL");
 		return ((IStrategoNamed) getWrapped()).getName();
 	}
 
 	@Override
 	public int intValue() {
-		if(getTermType() != INT)
+		if(getType() != TermType.INT)
 			throw new TermWrapperException("Called intValue() on a term that is not of type INT");
 		return ((IStrategoInt) getWrapped()).intValue();
 	}
@@ -177,21 +177,21 @@ public abstract class LazyTerm implements IStrategoAppl, IStrategoInt, IStratego
 	@Override
 	@Deprecated
 	public boolean isUniqueValueTerm() {
-		if(getTermType() != INT)
+		if(getType() != TermType.INT)
 			throw new TermWrapperException("Called isUniqueValueTerm() on a term that is not of type INT");
 		return ((IStrategoInt) getWrapped()).isUniqueValueTerm();
 	}
 
 	@Override
 	public double realValue() {
-		if(getTermType() != REAL)
+		if(getType() != TermType.REAL)
 			throw new TermWrapperException("Called realValue() on a term that is not of type REAL");
 		return ((IStrategoReal) getWrapped()).realValue();
 	}
 
 	@Override
 	public String stringValue() {
-		if(getTermType() != STRING)
+		if(getType() != TermType.STRING)
 			throw new TermWrapperException("Called stringValue() on a term that is not of type STRING");
 		return ((IStrategoString) getWrapped()).stringValue();
 	}

--- a/org.spoofax.terms/src/org/spoofax/terms/LazyTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/LazyTerm.java
@@ -4,10 +4,19 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoConstructor;
+import org.spoofax.interpreter.terms.IStrategoInt;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoNamed;
+import org.spoofax.interpreter.terms.IStrategoReal;
+import org.spoofax.interpreter.terms.IStrategoString;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.IStrategoTuple;
+import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 import org.spoofax.terms.attachments.ITermAttachment;
 import org.spoofax.terms.attachments.TermAttachmentType;
-import org.spoofax.terms.util.TermUtils;
 
 /**
  * A lazily initialized term,

--- a/org.spoofax.terms/src/org/spoofax/terms/SimpleTermVisitor.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/SimpleTermVisitor.java
@@ -4,8 +4,6 @@ import java.util.Iterator;
 
 import org.spoofax.interpreter.terms.ISimpleTerm;
 import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.terms.util.TermUtils;
 
 
 /**

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoAppl.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoAppl.java
@@ -61,8 +61,8 @@ public class StrategoAppl extends StrategoTerm implements IStrategoAppl {
     }
 
     @Override
-    public int getTermType() {
-        return IStrategoTerm.APPL;
+    public TermType getType() {
+        return TermType.APPL;
     }
 
     @Override

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoAppl.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoAppl.java
@@ -1,6 +1,11 @@
 package org.spoofax.terms;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoConstructor;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 import org.spoofax.terms.util.ArrayIterator;
 import org.spoofax.terms.util.TermUtils;
 

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoArrayList.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoArrayList.java
@@ -86,10 +86,6 @@ public class StrategoArrayList extends AbstractStrategoList implements RandomAcc
         return Arrays.copyOfRange(terms, offset, endOffset);
     }
 
-    @Override public int getTermType() {
-        return IStrategoTerm.LIST;
-    }
-
     @Deprecated @Override public IStrategoTerm get(int index) {
         return getSubterm(index);
     }

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoConstructor.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoConstructor.java
@@ -7,7 +7,13 @@
  */
 package org.spoofax.terms;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoConstructor;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermFactory;
+import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 import org.spoofax.terms.util.EmptyIterator;
 
 import java.io.IOException;

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoConstructor.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoConstructor.java
@@ -62,8 +62,8 @@ public final class StrategoConstructor extends StrategoTerm implements IStratego
     }
 
     @Override
-    public final int getTermType() {
-        return IStrategoTerm.CTOR;
+    public TermType getType() {
+        return TermType.CTOR;
     }
 
     @Override

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoConstructor.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoConstructor.java
@@ -70,7 +70,7 @@ public final class StrategoConstructor extends StrategoTerm implements IStratego
     protected boolean doSlowMatch(IStrategoTerm second) {
         if(second == this)
             return true;
-        if(second == null || second.getTermType() != CTOR)
+        if(second == null || second.getType() != TermType.CTOR)
             return false;
 
         IStrategoConstructor other = (IStrategoConstructor) second;

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoInt.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoInt.java
@@ -7,13 +7,11 @@
  */
 package org.spoofax.terms;
 
-import org.spoofax.interpreter.terms.IStrategoInt;
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.*;
 import org.spoofax.terms.util.EmptyIterator;
 import org.spoofax.terms.util.TermUtils;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
@@ -61,8 +59,8 @@ public class StrategoInt extends StrategoTerm implements IStrategoInt {
     }
 
     @Override
-    public int getTermType() {
-        return IStrategoTerm.INT;
+    public TermType getType() {
+        return TermType.INT;
     }
 
     @Override

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoInt.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoInt.java
@@ -7,11 +7,14 @@
  */
 package org.spoofax.terms;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoInt;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 import org.spoofax.terms.util.EmptyIterator;
 import org.spoofax.terms.util.TermUtils;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoList.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoList.java
@@ -3,6 +3,7 @@ package org.spoofax.terms;
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 import org.spoofax.terms.util.TermUtils;
 
 import javax.annotation.Nullable;
@@ -111,11 +112,6 @@ public class StrategoList extends AbstractStrategoList {
     @Override
     public int getSubtermCount() {
         return size;
-    }
-
-    @Override
-    public int getTermType() {
-        return IStrategoTerm.LIST;
     }
 
     @Override

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoList.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoList.java
@@ -116,7 +116,7 @@ public class StrategoList extends AbstractStrategoList {
 
     @Override
     protected boolean doSlowMatch(IStrategoTerm second) {
-        if(second.getTermType() != IStrategoTerm.LIST)
+        if(second.getType() != TermType.LIST)
             return false;
 
         final IStrategoList snd = (IStrategoList) second;

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoList.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoList.java
@@ -2,14 +2,9 @@ package org.spoofax.terms;
 
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.ITermPrinter;
 import org.spoofax.interpreter.terms.TermType;
-import org.spoofax.terms.util.TermUtils;
 
-import javax.annotation.Nullable;
-import java.io.IOException;
 import java.io.ObjectStreamException;
-import java.io.Serializable;
 import java.util.*;
 
 /**

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoPlaceholder.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoPlaceholder.java
@@ -1,6 +1,11 @@
 package org.spoofax.terms;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoConstructor;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoPlaceholder;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 
 import java.io.IOException;
 

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoPlaceholder.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoPlaceholder.java
@@ -21,13 +21,13 @@ public class StrategoPlaceholder extends StrategoAppl implements IStrategoPlaceh
     }
 
     @Override
-    public int getTermType() {
-        return PLACEHOLDER;
+    public TermType getType() {
+        return TermType.PLACEHOLDER;
     }
 
     @Override
     protected boolean doSlowMatch(IStrategoTerm second) {
-        if(second.getTermType() != PLACEHOLDER)
+        if(second.getType() != TermType.PLACEHOLDER)
             return false;
 
         if(!getTemplate().match(((IStrategoPlaceholder) second).getTemplate()))

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoReal.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoReal.java
@@ -7,7 +7,11 @@
  */
 package org.spoofax.terms;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoReal;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 import org.spoofax.terms.util.EmptyIterator;
 import org.spoofax.terms.util.TermUtils;
 

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoReal.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoReal.java
@@ -7,10 +7,7 @@
  */
 package org.spoofax.terms;
 
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoReal;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.*;
 import org.spoofax.terms.util.EmptyIterator;
 import org.spoofax.terms.util.TermUtils;
 
@@ -61,8 +58,8 @@ public class StrategoReal extends StrategoTerm implements IStrategoReal {
     }
 
     @Override
-    public int getTermType() {
-        return IStrategoTerm.REAL;
+    public TermType getType() {
+        return TermType.REAL;
     }
 
     @Override
@@ -100,6 +97,6 @@ public class StrategoReal extends StrategoTerm implements IStrategoReal {
     }
 
     public Iterator<IStrategoTerm> iterator() {
-        return new EmptyIterator<IStrategoTerm>();
+        return new EmptyIterator<>();
     }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoString.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoString.java
@@ -7,7 +7,11 @@
  */
 package org.spoofax.terms;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoString;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 import org.spoofax.terms.util.EmptyIterator;
 import org.spoofax.terms.util.StringUtils;
 import org.spoofax.terms.util.TermUtils;

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoString.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoString.java
@@ -7,10 +7,7 @@
  */
 package org.spoofax.terms;
 
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoString;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.*;
 import org.spoofax.terms.util.EmptyIterator;
 import org.spoofax.terms.util.StringUtils;
 import org.spoofax.terms.util.TermUtils;
@@ -58,8 +55,8 @@ public class StrategoString extends StrategoTerm implements IStrategoString {
     }
 
     @Override
-    public int getTermType() {
-        return IStrategoTerm.STRING;
+    public TermType getType() {
+        return TermType.STRING;
     }
 
     @Override

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoTerm.java
@@ -10,6 +10,7 @@ package org.spoofax.terms;
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 
 import java.io.IOException;
 import java.util.List;
@@ -167,9 +168,18 @@ public abstract class StrategoTerm extends AbstractSimpleTerm implements IStrate
         }
     }
 
+    @Override
+    @Deprecated
+    public int getTermType() {
+        return getType().getValue();
+    }
+
+    @Override
+    public abstract TermType getType();
+
     @Deprecated
     @Override
     public final boolean isList() {
-        return getTermType() == LIST;
+        return getType() == TermType.LIST;
     }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoTuple.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoTuple.java
@@ -1,12 +1,10 @@
 package org.spoofax.terms;
 
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.IStrategoTuple;
-import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.*;
 import org.spoofax.terms.util.ArrayIterator;
 import org.spoofax.terms.util.TermUtils;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -53,8 +51,8 @@ public class StrategoTuple extends StrategoTerm implements IStrategoTuple {
     }
 
     @Override
-    public int getTermType() {
-        return IStrategoTerm.TUPLE;
+    public TermType getType() {
+        return TermType.TUPLE;
     }
 
     @Override

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoTuple.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoTuple.java
@@ -1,12 +1,14 @@
 package org.spoofax.terms;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.IStrategoTuple;
+import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 import org.spoofax.terms.util.ArrayIterator;
 import org.spoofax.terms.util.TermUtils;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoWrapped.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoWrapped.java
@@ -116,21 +116,21 @@ public class StrategoWrapped extends StrategoTerm implements IStrategoAppl, IStr
 
 	@Override
 	public IStrategoTerm head() {
-		if (getTermType() != LIST)
+		if (getType() != TermType.LIST)
 			throw new TermWrapperException("Called head() on a term that is not of type LIST");
 		return ((IStrategoList) wrapped).head();
 	}
 
 	@Override
 	public IStrategoList tail() {
-		if (getTermType() != LIST)
+		if (getType() != TermType.LIST)
 			throw new TermWrapperException("Called tail() on a term that is not of type LIST");
 		return ((IStrategoList) wrapped).tail();
 	}
 
 	@Override
 	public boolean isEmpty() {
-		if (getTermType() != LIST)
+		if (getType() != TermType.LIST)
 			throw new TermWrapperException("Called isEmpty() on a term that is not of type LIST");
 		return ((IStrategoList) wrapped).isEmpty();
 	}
@@ -138,14 +138,14 @@ public class StrategoWrapped extends StrategoTerm implements IStrategoAppl, IStr
 	@Deprecated
 	@Override
 	public IStrategoList prepend(IStrategoTerm prefix) {
-		if (getTermType() != LIST)
+		if (getType() != TermType.LIST)
 			throw new TermWrapperException("Called prepend() on a term that is not of type LIST");
 		return ((IStrategoList) wrapped).prepend(prefix);
 	}
 
 	@Override
 	public int size() {
-		switch (getTermType()) {
+		switch (getType()) {
 			case LIST:
 				return ((IStrategoList) wrapped).size();
 			case TUPLE:
@@ -157,14 +157,14 @@ public class StrategoWrapped extends StrategoTerm implements IStrategoAppl, IStr
 
 	@Override
 	public IStrategoConstructor getConstructor() {
-		if (getTermType() != APPL)
+		if (getType() != TermType.APPL)
 			throw new TermWrapperException("Called getConstructor() on a term that is not of type APPL");
 		return ((IStrategoAppl) wrapped).getConstructor();
 	}
 
 	@Override
 	public int intValue() {
-		if (getTermType() != INT)
+		if (getType() != TermType.INT)
 			throw new TermWrapperException("Called intValue() on a term that is not of type INT");
 		return ((IStrategoInt) wrapped).intValue();
 	}
@@ -172,28 +172,28 @@ public class StrategoWrapped extends StrategoTerm implements IStrategoAppl, IStr
 	@Override
 	@Deprecated
 	public boolean isUniqueValueTerm() {
-		if (getTermType() != INT)
+		if (getType() != TermType.INT)
 			throw new TermWrapperException("Called isUniqueValueTerm() on a term that is not of type INT");
 		return ((IStrategoInt) wrapped).isUniqueValueTerm();
 	}
 
 	@Override
 	public double realValue() {
-		if (getTermType() != REAL)
+		if (getType() != TermType.REAL)
 			throw new TermWrapperException("Called realValue() on a term that is not of type REAL");
 		return ((IStrategoReal) wrapped).realValue();
 	}
 
 	@Override
 	public String getName() {
-		if (getTermType() != STRING && getTermType() != APPL)
+		if (getType() != TermType.STRING && getType() != TermType.APPL)
 			throw new TermWrapperException("Called getName() on a term that is not of type STRING or APPL");
 		return ((IStrategoNamed) wrapped).getName();
 	}
 
 	@Override
 	public String stringValue() {
-		if (getTermType() != STRING)
+		if (getType() != TermType.STRING)
 			throw new TermWrapperException("Called stringValue() on a term that is not of type STRING");
 		return ((IStrategoString) wrapped).stringValue();
 	}

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoWrapped.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoWrapped.java
@@ -4,9 +4,17 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
-import org.spoofax.interpreter.terms.*;
-
-import javax.annotation.Nullable;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoConstructor;
+import org.spoofax.interpreter.terms.IStrategoInt;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoNamed;
+import org.spoofax.interpreter.terms.IStrategoReal;
+import org.spoofax.interpreter.terms.IStrategoString;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.IStrategoTuple;
+import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 
 /**
  * A wrapped Stratego term of any type that supports attachments separate from its base term.

--- a/org.spoofax.terms/src/org/spoofax/terms/StrategoWrapped.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/StrategoWrapped.java
@@ -4,16 +4,9 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
-import org.spoofax.interpreter.terms.IStrategoAppl;
-import org.spoofax.interpreter.terms.IStrategoConstructor;
-import org.spoofax.interpreter.terms.IStrategoInt;
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoNamed;
-import org.spoofax.interpreter.terms.IStrategoReal;
-import org.spoofax.interpreter.terms.IStrategoString;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.IStrategoTuple;
-import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.*;
+
+import javax.annotation.Nullable;
 
 /**
  * A wrapped Stratego term of any type that supports attachments separate from its base term.
@@ -88,8 +81,8 @@ public class StrategoWrapped extends StrategoTerm implements IStrategoAppl, IStr
 	}
 
 	@Override
-	public int getTermType() {
-		return wrapped.getTermType();
+	public TermType getType() {
+		return wrapped.getType();
 	}
 
 	@Deprecated

--- a/org.spoofax.terms/src/org/spoofax/terms/Term.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/Term.java
@@ -1,6 +1,10 @@
 package org.spoofax.terms;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoConstructor;
+import org.spoofax.interpreter.terms.IStrategoString;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermFactory;
 import org.spoofax.terms.util.TermUtils;
 
 /** @deprecated Use {@link TermUtils} */

--- a/org.spoofax.terms/src/org/spoofax/terms/Term.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/Term.java
@@ -3,8 +3,6 @@ package org.spoofax.terms;
 import org.spoofax.interpreter.terms.*;
 import org.spoofax.terms.util.TermUtils;
 
-import static org.spoofax.interpreter.terms.IStrategoTerm.TUPLE;
-
 /** @deprecated Use {@link TermUtils} */
 @Deprecated
 public class Term {
@@ -122,14 +120,14 @@ public class Term {
     public static IStrategoTerm removeAnnotations(IStrategoTerm inTerm, final ITermFactory factory) {
         TermTransformer trans = new TermTransformer(factory, true) {
             @Override public IStrategoTerm preTransform(IStrategoTerm term) {
-                switch(term.getTermType()) {
-                    case IStrategoTerm.APPL:
+                switch(term.getType()) {
+                    case APPL:
                         return factory.makeAppl(((IStrategoAppl) term).getConstructor(), term.getAllSubterms(), null);
-                    case IStrategoTerm.LIST:
+                    case LIST:
                         return factory.makeList(term.getAllSubterms(), null);
-                    case IStrategoTerm.STRING:
+                    case STRING:
                         return factory.makeString(((IStrategoString) term).stringValue());
-                    case IStrategoTerm.TUPLE:
+                    case TUPLE:
                         return factory.makeTuple(term.getAllSubterms(), null);
                     default:
                         return term;

--- a/org.spoofax.terms/src/org/spoofax/terms/TermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/TermFactory.java
@@ -13,8 +13,6 @@ import org.spoofax.interpreter.terms.ITermFactory;
 import org.spoofax.terms.util.StringInterner;
 import org.spoofax.terms.util.TermUtils;
 
-import static org.spoofax.interpreter.terms.IStrategoTerm.STRING;
-
 public class TermFactory extends AbstractTermFactory implements ITermFactory {
     private static final int MAX_POOLED_STRING_LENGTH = 200;
     private static final StringInterner usedStrings = new StringInterner();

--- a/org.spoofax.terms/src/org/spoofax/terms/TermList.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/TermList.java
@@ -4,8 +4,6 @@ import org.spoofax.interpreter.terms.IStrategoTerm;
 
 import java.io.Serializable;
 import java.util.*;
-import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 import java.util.stream.StreamSupport;
 
 /**

--- a/org.spoofax.terms/src/org/spoofax/terms/TermTransformer.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/TermTransformer.java
@@ -1,6 +1,10 @@
 package org.spoofax.terms;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermFactory;
+import org.spoofax.interpreter.terms.TermType;
 
 /**
  * An abstract, top-down transformation class

--- a/org.spoofax.terms/src/org/spoofax/terms/TermTransformer.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/TermTransformer.java
@@ -1,13 +1,6 @@
 package org.spoofax.terms;
 
-import static org.spoofax.interpreter.terms.IStrategoTerm.APPL;
-import static org.spoofax.interpreter.terms.IStrategoTerm.LIST;
-import static org.spoofax.interpreter.terms.IStrategoTerm.TUPLE;
-
-import org.spoofax.interpreter.terms.IStrategoAppl;
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.ITermFactory;
+import org.spoofax.interpreter.terms.*;
 
 /**
  * An abstract, top-down transformation class
@@ -39,10 +32,10 @@ public abstract class TermTransformer {
 	}
 
 	public IStrategoTerm simpleAll(IStrategoTerm current) {
-		int termType = current.getTermType();
+		TermType termType = current.getType();
 		IStrategoTerm result;
 		
-		if (termType == LIST) {
+		if (termType == TermType.LIST) {
 			result = simpleMapIgnoreAnnos((IStrategoList) current);
 		} else {
 			IStrategoTerm[] inputs = current.getAllSubterms();

--- a/org.spoofax.terms/src/org/spoofax/terms/TermVisitor.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/TermVisitor.java
@@ -2,7 +2,6 @@ package org.spoofax.terms;
 
 import java.util.Iterator;
 
-import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.terms.util.TermUtils;
 

--- a/org.spoofax.terms/src/org/spoofax/terms/UniqueValueTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/UniqueValueTerm.java
@@ -6,7 +6,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoInt;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 import org.spoofax.terms.util.EmptyIterator;
 
 /**

--- a/org.spoofax.terms/src/org/spoofax/terms/UniqueValueTerm.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/UniqueValueTerm.java
@@ -6,10 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.spoofax.interpreter.terms.IStrategoInt;
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.*;
 import org.spoofax.terms.util.EmptyIterator;
 
 /**
@@ -50,8 +47,14 @@ public final class UniqueValueTerm extends AbstractSimpleTerm implements IStrate
 		return 0;
 	}
 
+	@Deprecated
 	public int getTermType() {
-		return INT;
+		return getType().getValue();
+	}
+
+	@Override
+	public TermType getType() {
+		return TermType.INT;
 	}
 	
 	public boolean isUniqueValueTerm() {
@@ -96,7 +99,7 @@ public final class UniqueValueTerm extends AbstractSimpleTerm implements IStrate
 	}
 
 	public Iterator<IStrategoTerm> iterator() {
-		return new EmptyIterator<IStrategoTerm>();
+		return new EmptyIterator<>();
 	}
 	
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/attachments/OriginTermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/attachments/OriginTermFactory.java
@@ -103,7 +103,7 @@ public abstract class OriginTermFactory extends AbstractWrappedTermFactory {
 				return false;
 		}
 		return 	
-			term.getTermType() == origin.getTermType() && 
+			term.getType() == origin.getType() &&
 			term.getSubtermCount() == origin.getSubtermCount();
 	}
 

--- a/org.spoofax.terms/src/org/spoofax/terms/io/SimpleTextTermWriter.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/io/SimpleTextTermWriter.java
@@ -1,6 +1,14 @@
 package org.spoofax.terms.io;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoInt;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoPlaceholder;
+import org.spoofax.interpreter.terms.IStrategoReal;
+import org.spoofax.interpreter.terms.IStrategoRef;
+import org.spoofax.interpreter.terms.IStrategoString;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.IStrategoTuple;
 import org.spoofax.terms.attachments.ITermAttachment;
 import org.spoofax.terms.util.StringUtils;
 

--- a/org.spoofax.terms/src/org/spoofax/terms/io/SimpleTextTermWriter.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/io/SimpleTextTermWriter.java
@@ -109,33 +109,33 @@ public class SimpleTextTermWriter implements TextTermWriter {
             return;
         }
 
-        switch(term.getTermType()) {
-            case IStrategoTerm.APPL:
+        switch(term.getType()) {
+            case APPL:
                 writeApplBody((IStrategoAppl)term, writer, depth, isAnnotation);
                 break;
-            case IStrategoTerm.LIST:
+            case LIST:
                 writeListBody((IStrategoList)term, writer, depth, isAnnotation);
                 break;
-            case IStrategoTerm.TUPLE:
+            case TUPLE:
                 writeTupleBody((IStrategoTuple)term, writer, depth, isAnnotation);
                 break;
-            case IStrategoTerm.INT:
+            case INT:
                 writeIntBody((IStrategoInt)term, writer, depth, isAnnotation);
                 break;
-            case IStrategoTerm.REAL:
+            case REAL:
                 writeRealBody((IStrategoReal)term, writer, depth, isAnnotation);
                 break;
-            case IStrategoTerm.STRING:
+            case STRING:
                 writeStringBody((IStrategoString)term, writer, depth, isAnnotation);
                 break;
-            case IStrategoTerm.REF:
+            case REF:
                 writeRefBody((IStrategoRef)term, writer, depth, isAnnotation);
                 break;
-            case IStrategoTerm.PLACEHOLDER:
+            case PLACEHOLDER:
                 writePlaceholderBody((IStrategoPlaceholder)term, writer, depth, isAnnotation);
                 break;
             default:
-                throw new RuntimeException("Unknown term type: " + term.getTermType() + " for term of type " + term.getClass().getSimpleName());
+                throw new RuntimeException("Unknown term type: " + term.getType() + " for term of type " + term.getClass().getSimpleName());
         }
 
         if(termHasAnnotations(term, isAnnotation)) writeAnnotations(term, writer, depth, isAnnotation);

--- a/org.spoofax.terms/src/org/spoofax/terms/io/binary/ATermConstants.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/io/binary/ATermConstants.java
@@ -1,12 +1,5 @@
 package org.spoofax.terms.io.binary;
 
-import static org.spoofax.interpreter.terms.IStrategoTerm.APPL;
-import static org.spoofax.interpreter.terms.IStrategoTerm.INT;
-import static org.spoofax.interpreter.terms.IStrategoTerm.LIST;
-import static org.spoofax.interpreter.terms.IStrategoTerm.REAL;
-import static org.spoofax.interpreter.terms.IStrategoTerm.STRING;
-import static org.spoofax.interpreter.terms.IStrategoTerm.TUPLE;
-
 import org.spoofax.interpreter.terms.IStrategoTerm;
 
 public class ATermConstants {
@@ -20,7 +13,7 @@ public class ATermConstants {
     public static final int AT_LIST = 4;
 
     public static int ATermTypeForTerm(IStrategoTerm term) {
-    	switch (term.getTermType()) {
+    	switch (term.getType()) {
     		case APPL:  case STRING: case TUPLE: return AT_APPL;
     		case INT: return AT_INT;
     		case REAL: return AT_REAL;

--- a/org.spoofax.terms/src/org/spoofax/terms/io/binary/SAFReader.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/io/binary/SAFReader.java
@@ -502,7 +502,7 @@ class SAFReader {
             } else {
                 throw new RuntimeException(
                         "Encountered a term that didn't fit anywhere. Type: "
-                                + term.getTermType() + ", term " + term);
+                                + term.getType() + ", term " + term);
             }
 
             term = buildTerm(parent);

--- a/org.spoofax.terms/src/org/spoofax/terms/io/binary/SAFWriter.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/io/binary/SAFWriter.java
@@ -28,25 +28,14 @@
 
 package org.spoofax.terms.io.binary;
 
-import static org.spoofax.interpreter.terms.IStrategoTerm.APPL;
-import static org.spoofax.interpreter.terms.IStrategoTerm.INT;
-import static org.spoofax.interpreter.terms.IStrategoTerm.LIST;
-import static org.spoofax.interpreter.terms.IStrategoTerm.REAL;
-import static org.spoofax.interpreter.terms.IStrategoTerm.STRING;
-import static org.spoofax.interpreter.terms.IStrategoTerm.TUPLE;
-
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.spoofax.interpreter.terms.IStrategoAppl;
@@ -197,7 +186,7 @@ private final static class SAFWriterInternal {
      */
     protected void visit(IStrategoTerm term) {
 
-        switch (term.getTermType()) {
+        switch (term.getType()) {
         	case APPL:
         		voidVisitAppl((IStrategoAppl) term);
         		break;
@@ -217,7 +206,7 @@ private final static class SAFWriterInternal {
         		voidVisitTuple((IStrategoTuple) term);
         		break;
         	default:
-        		throw new RuntimeException("Could not serializate term of type "
+        		throw new RuntimeException("Could not serialize term of type "
                     + term.getClass().getName() + " to SAF format.");
         }
 

--- a/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoAppl.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoAppl.java
@@ -4,7 +4,11 @@ package org.spoofax.terms.skeleton;
 import java.io.IOException;
 import java.util.Iterator;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 import org.spoofax.terms.StrategoTerm;
 import org.spoofax.terms.util.ArrayIterator;
 import org.spoofax.terms.util.NotImplementedException;

--- a/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoAppl.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoAppl.java
@@ -4,10 +4,7 @@ package org.spoofax.terms.skeleton;
 import java.io.IOException;
 import java.util.Iterator;
 
-import org.spoofax.interpreter.terms.IStrategoAppl;
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.*;
 import org.spoofax.terms.StrategoTerm;
 import org.spoofax.terms.util.ArrayIterator;
 import org.spoofax.terms.util.NotImplementedException;
@@ -26,20 +23,24 @@ public abstract class SkeletonStrategoAppl extends StrategoTerm implements IStra
 		throw new NotImplementedException();
 	}
 
-	final public String getName() {
+	@Override final public String getName() {
 		return getConstructor().getName();
 	}
 
-	final public int getSubtermCount() {
+	@Override final public int getSubtermCount() {
 		return getConstructor().getArity();
 	}
 
-	final public int getTermType() {
-		return IStrategoTerm.APPL;
+	@Deprecated
+	@Override final public int getTermType() {
+		return getType().getValue();
 	}
 
-	@Override
-	final protected boolean doSlowMatch(IStrategoTerm second) {
+	@Override final public TermType getType() {
+		return TermType.APPL;
+	}
+
+	@Override final protected boolean doSlowMatch(IStrategoTerm second) {
 		if(!TermUtils.isAppl(second))
 			return false;
 		final IStrategoAppl o = (IStrategoAppl) second;
@@ -66,7 +67,7 @@ public abstract class SkeletonStrategoAppl extends StrategoTerm implements IStra
 			return annotations.match(secondAnnotations);
 	}
 
-	final public void writeAsString(Appendable output, int maxDepth) throws IOException {
+	@Override final public void writeAsString(Appendable output, int maxDepth) throws IOException {
 		output.append(getName());
 		final IStrategoTerm[] kids = getAllSubterms();
 		if(kids.length > 0) {
@@ -86,12 +87,11 @@ public abstract class SkeletonStrategoAppl extends StrategoTerm implements IStra
 	}
 
 	@Deprecated
-	public final void prettyPrint(ITermPrinter pp) {
+	@Override public final void prettyPrint(ITermPrinter pp) {
 		new NotImplementedException();
 	}
 
-	@Override
-	final protected int hashFunction() {
+	@Override final protected int hashFunction() {
 		long r = getConstructor().hashCode();
 		int accum = 6673;
 		final IStrategoTerm[] kids = getAllSubterms();
@@ -102,7 +102,7 @@ public abstract class SkeletonStrategoAppl extends StrategoTerm implements IStra
 		return (int) (r >> 12);
 	}
 
-	public Iterator<IStrategoTerm> iterator() {
+	@Override public Iterator<IStrategoTerm> iterator() {
 		return new ArrayIterator<IStrategoTerm>(getAllSubterms());
 	}
 

--- a/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoInt.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoInt.java
@@ -5,10 +5,7 @@
  */
 package org.spoofax.terms.skeleton;
 
-import org.spoofax.interpreter.terms.IStrategoInt;
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.*;
 import org.spoofax.terms.StrategoTerm;
 import org.spoofax.terms.TermFactory;
 import org.spoofax.terms.util.EmptyIterator;
@@ -58,8 +55,9 @@ public class SkeletonStrategoInt extends StrategoTerm implements IStrategoInt {
         return 0;
     }
 
-    public int getTermType() {
-        return IStrategoTerm.INT;
+    @Override
+    public TermType getType() {
+        return TermType.INT;
     }
 
     public boolean isUniqueValueTerm() {

--- a/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoInt.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoInt.java
@@ -5,7 +5,11 @@
  */
 package org.spoofax.terms.skeleton;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoInt;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 import org.spoofax.terms.StrategoTerm;
 import org.spoofax.terms.TermFactory;
 import org.spoofax.terms.util.EmptyIterator;

--- a/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoList.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoList.java
@@ -18,7 +18,6 @@ import org.spoofax.terms.util.TermUtils;
 
 import java.io.IOException;
 import java.util.Iterator;
-import java.util.List;
 
 public abstract class SkeletonStrategoList extends StrategoTerm implements IStrategoList, Iterable<IStrategoTerm> {
 

--- a/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoList.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonStrategoList.java
@@ -8,6 +8,7 @@ package org.spoofax.terms.skeleton;
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 import org.spoofax.terms.StrategoListIterator;
 import org.spoofax.terms.StrategoTerm;
 import org.spoofax.terms.attachments.ITermAttachment;
@@ -37,25 +38,29 @@ public abstract class SkeletonStrategoList extends StrategoTerm implements IStra
     }
 
     @Deprecated
-    public final IStrategoList prepend(IStrategoTerm prefix) {
+    @Override public final IStrategoList prepend(IStrategoTerm prefix) {
         throw new NotImplementedException();
     }
 
     @Deprecated
-    public final IStrategoTerm get(int index) {
+    @Override public final IStrategoTerm get(int index) {
         throw new NotImplementedException();
     }
 
-    public final int size() {
+    @Override public final int size() {
         return getSubtermCount();
     }
 
-    public final int getTermType() {
-        return IStrategoTerm.LIST;
+    @Deprecated
+    @Override public final int getTermType() {
+        return getType().getValue();
     }
 
-    @Override
-    protected boolean doSlowMatch(IStrategoTerm second) {
+    @Override public final TermType getType() {
+        return TermType.LIST;
+    }
+
+    @Override protected boolean doSlowMatch(IStrategoTerm second) {
         if(!TermUtils.isList(second))
             return false;
 
@@ -89,11 +94,11 @@ public abstract class SkeletonStrategoList extends StrategoTerm implements IStra
             return annotations.match(secondAnnotations);
     }
 
-    public final void prettyPrint(ITermPrinter pp) {
+    @Override public final void prettyPrint(ITermPrinter pp) {
         throw new NotImplementedException();
     }
 
-    public final void writeAsString(Appendable output, int maxDepth) throws IOException {
+    @Override public final void writeAsString(Appendable output, int maxDepth) throws IOException {
         output.append('[');
         if(!isEmpty()) {
             if(maxDepth == 0) {
@@ -111,8 +116,7 @@ public abstract class SkeletonStrategoList extends StrategoTerm implements IStra
         appendAnnotations(output, maxDepth);
     }
 
-    @Override
-    public int hashFunction() {
+    @Override public int hashFunction() {
         /* UNDONE: BasicStrategoTerm hash; should use cons/nil hash instead
         long hc = 4787;
         for (IStrategoList cur = this; !cur.isEmpty(); cur = cur.tail()) {
@@ -127,32 +131,27 @@ public abstract class SkeletonStrategoList extends StrategoTerm implements IStra
         return result;
     }
 
-    public final Iterator<IStrategoTerm> iterator() {
+    @Override public final Iterator<IStrategoTerm> iterator() {
         return new StrategoListIterator(this);
     }
 
-    @Override
-    public final String toString(int maxDepth) {
+    @Override public final String toString(int maxDepth) {
         return super.toString(maxDepth);
     }
 
-    @Override
-    public final <T extends ITermAttachment> T getAttachment(TermAttachmentType<T> type) {
+    @Override public final <T extends ITermAttachment> T getAttachment(TermAttachmentType<T> type) {
         return super.getAttachment(type);
     }
 
-    @Override
-    public final void putAttachment(ITermAttachment attachment) {
+    @Override public final void putAttachment(ITermAttachment attachment) {
         super.putAttachment(attachment);
     }
 
-    @Override
-    public final ITermAttachment removeAttachment(TermAttachmentType<?> type) {
+    @Override public final ITermAttachment removeAttachment(TermAttachmentType<?> type) {
         return super.removeAttachment(type);
     }
 
-    @Override
-    protected final void clearAttachments() {
+    @Override protected final void clearAttachments() {
         super.clearAttachments();
     }
 }

--- a/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonTermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/skeleton/SkeletonTermFactory.java
@@ -6,7 +6,6 @@ import org.spoofax.interpreter.terms.IStrategoPlaceholder;
 import org.spoofax.interpreter.terms.IStrategoReal;
 import org.spoofax.interpreter.terms.IStrategoString;
 import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.ITermFactory;
 import org.spoofax.terms.AbstractTermFactory;
 import org.spoofax.terms.util.NotImplementedException;
 

--- a/org.spoofax.terms/src/org/spoofax/terms/util/StringInterner.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/util/StringInterner.java
@@ -1,8 +1,6 @@
 package org.spoofax.terms.util;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
-import java.io.Serializable;
 import java.lang.ref.WeakReference;
 import java.util.*;
 import java.util.function.Consumer;

--- a/org.spoofax.terms/src/org/spoofax/terms/util/TermUtils.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/util/TermUtils.java
@@ -1,6 +1,14 @@
 package org.spoofax.terms.util;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoConstructor;
+import org.spoofax.interpreter.terms.IStrategoInt;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoReal;
+import org.spoofax.interpreter.terms.IStrategoString;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.IStrategoTuple;
+import org.spoofax.interpreter.terms.TermType;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;

--- a/org.spoofax.terms/src/org/spoofax/terms/util/TermUtils.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/util/TermUtils.java
@@ -26,8 +26,8 @@ public final class TermUtils {
      * @return {@code true} when the term is a String term; otherwise, {@code false}
      */
     public static boolean isString(IStrategoTerm term) {
-        boolean isString = (term != null && term.getTermType() == IStrategoTerm.STRING);
-        assert !isString || (term instanceof IStrategoString) : getTypeMismatchAssertionMessage(IStrategoString.class, IStrategoList.STRING, term);
+        boolean isString = (term != null && term.getType() == TermType.STRING);
+        assert !isString || (term instanceof IStrategoString) : getTypeMismatchAssertionMessage(IStrategoString.class, TermType.STRING, term);
         return isString;
     }
 
@@ -49,8 +49,8 @@ public final class TermUtils {
      * @return {@code true} when the term is an Int term; otherwise, {@code false}
      */
     public static boolean isInt(IStrategoTerm term) {
-        boolean isInt = (term != null && term.getTermType() == IStrategoTerm.INT);
-        assert !isInt || (term instanceof IStrategoInt) : getTypeMismatchAssertionMessage(IStrategoInt.class, IStrategoList.INT, term);
+        boolean isInt = (term != null && term.getType() == TermType.INT);
+        assert !isInt || (term instanceof IStrategoInt) : getTypeMismatchAssertionMessage(IStrategoInt.class, TermType.INT, term);
         return isInt;
     }
 
@@ -72,8 +72,8 @@ public final class TermUtils {
      * @return {@code true} when the term is a Real term; otherwise, {@code false}
      */
     public static boolean isReal(IStrategoTerm term) {
-        boolean isReal = (term != null && term.getTermType() == IStrategoTerm.REAL);
-        assert !isReal || (term instanceof IStrategoReal) : getTypeMismatchAssertionMessage(IStrategoReal.class, IStrategoList.REAL, term);
+        boolean isReal = (term != null && term.getType() == TermType.REAL);
+        assert !isReal || (term instanceof IStrategoReal) : getTypeMismatchAssertionMessage(IStrategoReal.class, TermType.REAL, term);
         return isReal;
     }
 
@@ -95,8 +95,8 @@ public final class TermUtils {
      * @return {@code true} when the term is a constructor application term; otherwise, {@code false}
      */
     public static boolean isAppl(IStrategoTerm term) {
-        boolean isAppl = (term != null && term.getTermType() == IStrategoTerm.APPL);
-        assert !isAppl || (term instanceof IStrategoAppl) : getTypeMismatchAssertionMessage(IStrategoAppl.class, IStrategoList.APPL, term);
+        boolean isAppl = (term != null && term.getType() == TermType.APPL);
+        assert !isAppl || (term instanceof IStrategoAppl) : getTypeMismatchAssertionMessage(IStrategoAppl.class, TermType.APPL, term);
         return isAppl;
     }
 
@@ -149,8 +149,8 @@ public final class TermUtils {
      * @return {@code true} when the term is a List term; otherwise, {@code false}
      */
     public static boolean isList(IStrategoTerm term) {
-        boolean isList = (term != null && term.getTermType() == IStrategoTerm.LIST);
-        assert !isList || (term instanceof IStrategoList) : getTypeMismatchAssertionMessage(IStrategoList.class, IStrategoList.LIST, term);
+        boolean isList = (term != null && term.getType() == TermType.LIST);
+        assert !isList || (term instanceof IStrategoList) : getTypeMismatchAssertionMessage(IStrategoList.class, TermType.LIST, term);
         return isList;
     }
 
@@ -172,8 +172,8 @@ public final class TermUtils {
      * @return {@code true} when the term is a Tuple term; otherwise, {@code false}
      */
     public static boolean isTuple(IStrategoTerm term) {
-        boolean isTuple = (term != null && term.getTermType() == IStrategoTerm.TUPLE);
-        assert !isTuple || (term instanceof IStrategoTuple) : getTypeMismatchAssertionMessage(IStrategoTuple.class, IStrategoList.TUPLE, term);
+        boolean isTuple = (term != null && term.getType() == TermType.TUPLE);
+        assert !isTuple || (term instanceof IStrategoTuple) : getTypeMismatchAssertionMessage(IStrategoTuple.class, TermType.TUPLE, term);
         return isTuple;
     }
 
@@ -310,8 +310,8 @@ public final class TermUtils {
      * @throws NullPointerException The term is null.
      */
     public static IStrategoString toString(IStrategoTerm term) {
-        if (term == null) throw newTermNullException(IStrategoTerm.STRING);
-        return asString(term).orElseThrow(() -> newTermCastException(IStrategoTerm.STRING, term.getTermType()));
+        if (term == null) throw newTermNullException(TermType.STRING);
+        return asString(term).orElseThrow(() -> newTermCastException(TermType.STRING, term.getType()));
     }
 
     /**
@@ -323,8 +323,8 @@ public final class TermUtils {
      * @throws NullPointerException The term is null.
      */
     public static IStrategoInt toInt(IStrategoTerm term) {
-        if (term == null) throw newTermNullException(IStrategoTerm.INT);
-        return asInt(term).orElseThrow(() -> newTermCastException(IStrategoTerm.INT, term.getTermType()));
+        if (term == null) throw newTermNullException(TermType.INT);
+        return asInt(term).orElseThrow(() -> newTermCastException(TermType.INT, term.getType()));
     }
 
     /**
@@ -336,8 +336,8 @@ public final class TermUtils {
      * @throws NullPointerException The term is null.
      */
     public static IStrategoReal toReal(IStrategoTerm term) {
-        if (term == null) throw newTermNullException(IStrategoTerm.REAL);
-        return asReal(term).orElseThrow(() -> newTermCastException(IStrategoTerm.REAL, term.getTermType()));
+        if (term == null) throw newTermNullException(TermType.REAL);
+        return asReal(term).orElseThrow(() -> newTermCastException(TermType.REAL, term.getType()));
     }
 
     /**
@@ -349,8 +349,8 @@ public final class TermUtils {
      * @throws NullPointerException The term is null.
      */
     public static IStrategoAppl toAppl(IStrategoTerm term) {
-        if (term == null) throw newTermNullException(IStrategoTerm.APPL);
-        return asAppl(term).orElseThrow(() -> newTermCastException(IStrategoTerm.APPL, term.getTermType()));
+        if (term == null) throw newTermNullException(TermType.APPL);
+        return asAppl(term).orElseThrow(() -> newTermCastException(TermType.APPL, term.getType()));
     }
 
     /**
@@ -362,8 +362,8 @@ public final class TermUtils {
      * @throws NullPointerException The term is null.
      */
     public static IStrategoList toList(IStrategoTerm term) {
-        if (term == null) throw newTermNullException(IStrategoTerm.LIST);
-        return asList(term).orElseThrow(() -> newTermCastException(IStrategoTerm.LIST, term.getTermType()));
+        if (term == null) throw newTermNullException(TermType.LIST);
+        return asList(term).orElseThrow(() -> newTermCastException(TermType.LIST, term.getType()));
     }
 
     /**
@@ -375,8 +375,8 @@ public final class TermUtils {
      * @throws NullPointerException The term is null.
      */
     public static IStrategoTuple toTuple(IStrategoTerm term) {
-        if (term == null) throw newTermNullException(IStrategoTerm.TUPLE);
-        return asTuple(term).orElseThrow(() -> newTermCastException(IStrategoTerm.TUPLE, term.getTermType()));
+        if (term == null) throw newTermNullException(TermType.TUPLE);
+        return asTuple(term).orElseThrow(() -> newTermCastException(TermType.TUPLE, term.getType()));
     }
 
 
@@ -392,8 +392,8 @@ public final class TermUtils {
      * @throws NullPointerException The term is null.
      */
     public static String toJavaString(IStrategoTerm term) {
-        if (term == null) throw newTermNullException(IStrategoTerm.STRING);
-        return asJavaString(term).orElseThrow(() -> newTermCastException(IStrategoTerm.STRING, term.getTermType()));
+        if (term == null) throw newTermNullException(TermType.STRING);
+        return asJavaString(term).orElseThrow(() -> newTermCastException(TermType.STRING, term.getType()));
     }
 
     /**
@@ -405,8 +405,8 @@ public final class TermUtils {
      * @throws NullPointerException The term is null.
      */
     public static int toJavaInt(IStrategoTerm term) {
-        if (term == null) throw newTermNullException(IStrategoTerm.INT);
-        return asJavaInt(term).orElseThrow(() -> newTermCastException(IStrategoTerm.INT, term.getTermType()));
+        if (term == null) throw newTermNullException(TermType.INT);
+        return asJavaInt(term).orElseThrow(() -> newTermCastException(TermType.INT, term.getType()));
     }
 
     /**
@@ -418,8 +418,8 @@ public final class TermUtils {
      * @throws NullPointerException The term is null.
      */
     public static double toJavaReal(IStrategoTerm term) {
-        if (term == null) throw newTermNullException(IStrategoTerm.REAL);
-        return asJavaReal(term).orElseThrow(() -> newTermCastException(IStrategoTerm.REAL, term.getTermType()));
+        if (term == null) throw newTermNullException(TermType.REAL);
+        return asJavaReal(term).orElseThrow(() -> newTermCastException(TermType.REAL, term.getType()));
     }
 
     /**
@@ -431,8 +431,8 @@ public final class TermUtils {
      * @throws NullPointerException The term is null.
      */
     public static List<IStrategoTerm> toJavaList(IStrategoTerm term) {
-        if (term == null) throw newTermNullException(IStrategoTerm.LIST);
-        return asJavaList(term).orElseThrow(() -> newTermCastException(IStrategoTerm.LIST, term.getTermType()));
+        if (term == null) throw newTermNullException(TermType.LIST);
+        return asJavaList(term).orElseThrow(() -> newTermCastException(TermType.LIST, term.getType()));
     }
 
 
@@ -764,8 +764,8 @@ public final class TermUtils {
     public static IStrategoString toStringAt(IStrategoTerm term, int index) {
         if (term == null) throw newTermNullException();
         IStrategoTerm subterm = term.getSubterm(index);
-        if (subterm == null) throw newTermNullException(IStrategoTerm.STRING, index);
-        return asString(subterm).orElseThrow(() -> newTermCastException(IStrategoTerm.STRING, term.getTermType(), index));
+        if (subterm == null) throw newTermNullException(TermType.STRING, index);
+        return asString(subterm).orElseThrow(() -> newTermCastException(TermType.STRING, term.getType(), index));
     }
 
     /**
@@ -781,8 +781,8 @@ public final class TermUtils {
     public static IStrategoInt toIntAt(IStrategoTerm term, int index) {
         if (term == null) throw newTermNullException();
         IStrategoTerm subterm = term.getSubterm(index);
-        if (subterm == null) throw newTermNullException(IStrategoTerm.INT, index);
-        return asInt(subterm).orElseThrow(() -> newTermCastException(IStrategoTerm.INT, term.getTermType(), index));
+        if (subterm == null) throw newTermNullException(TermType.INT, index);
+        return asInt(subterm).orElseThrow(() -> newTermCastException(TermType.INT, term.getType(), index));
     }
 
     /**
@@ -798,8 +798,8 @@ public final class TermUtils {
     public static IStrategoReal toRealAt(IStrategoTerm term, int index) {
         if (term == null) throw newTermNullException();
         IStrategoTerm subterm = term.getSubterm(index);
-        if (subterm == null) throw newTermNullException(IStrategoTerm.REAL, index);
-        return asReal(subterm).orElseThrow(() -> newTermCastException(IStrategoTerm.REAL, term.getTermType(), index));
+        if (subterm == null) throw newTermNullException(TermType.REAL, index);
+        return asReal(subterm).orElseThrow(() -> newTermCastException(TermType.REAL, term.getType(), index));
     }
 
     /**
@@ -815,8 +815,8 @@ public final class TermUtils {
     public static IStrategoAppl toApplAt(IStrategoTerm term, int index) {
         if (term == null) throw newTermNullException();
         IStrategoTerm subterm = term.getSubterm(index);
-        if (subterm == null) throw newTermNullException(IStrategoTerm.APPL, index);
-        return asAppl(subterm).orElseThrow(() -> newTermCastException(IStrategoTerm.APPL, term.getTermType(), index));
+        if (subterm == null) throw newTermNullException(TermType.APPL, index);
+        return asAppl(subterm).orElseThrow(() -> newTermCastException(TermType.APPL, term.getType(), index));
     }
 
     /**
@@ -832,8 +832,8 @@ public final class TermUtils {
     public static IStrategoList toListAt(IStrategoTerm term, int index) {
         if (term == null) throw newTermNullException();
         IStrategoTerm subterm = term.getSubterm(index);
-        if (subterm == null) throw newTermNullException(IStrategoTerm.LIST, index);
-        return asList(subterm).orElseThrow(() -> newTermCastException(IStrategoTerm.LIST, term.getTermType(), index));
+        if (subterm == null) throw newTermNullException(TermType.LIST, index);
+        return asList(subterm).orElseThrow(() -> newTermCastException(TermType.LIST, term.getType(), index));
     }
 
     /**
@@ -849,8 +849,8 @@ public final class TermUtils {
     public static IStrategoTuple toTupleAt(IStrategoTerm term, int index) {
         if (term == null) throw newTermNullException();
         IStrategoTerm subterm = term.getSubterm(index);
-        if (subterm == null) throw newTermNullException(IStrategoTerm.TUPLE, index);
-        return asTuple(subterm).orElseThrow(() -> newTermCastException(IStrategoTerm.TUPLE, term.getTermType(), index));
+        if (subterm == null) throw newTermNullException(TermType.TUPLE, index);
+        return asTuple(subterm).orElseThrow(() -> newTermCastException(TermType.TUPLE, term.getType(), index));
     }
 
 
@@ -870,8 +870,8 @@ public final class TermUtils {
     public static String toJavaStringAt(IStrategoTerm term, int index) {
         if (term == null) throw newTermNullException();
         IStrategoTerm subterm = term.getSubterm(index);
-        if (subterm == null) throw newTermNullException(IStrategoTerm.STRING, index);
-        return asJavaString(subterm).orElseThrow(() -> newTermCastException(IStrategoTerm.STRING, term.getTermType(), index));
+        if (subterm == null) throw newTermNullException(TermType.STRING, index);
+        return asJavaString(subterm).orElseThrow(() -> newTermCastException(TermType.STRING, term.getType(), index));
     }
 
     /**
@@ -887,8 +887,8 @@ public final class TermUtils {
     public static int toJavaIntAt(IStrategoTerm term, int index) {
         if (term == null) throw newTermNullException();
         IStrategoTerm subterm = term.getSubterm(index);
-        if (subterm == null) throw newTermNullException(IStrategoTerm.INT, index);
-        return asJavaInt(subterm).orElseThrow(() -> newTermCastException(IStrategoTerm.INT, term.getTermType(), index));
+        if (subterm == null) throw newTermNullException(TermType.INT, index);
+        return asJavaInt(subterm).orElseThrow(() -> newTermCastException(TermType.INT, term.getType(), index));
     }
 
     /**
@@ -904,8 +904,8 @@ public final class TermUtils {
     public static double toJavaRealAt(IStrategoTerm term, int index) {
         if (term == null) throw newTermNullException();
         IStrategoTerm subterm = term.getSubterm(index);
-        if (subterm == null) throw newTermNullException(IStrategoTerm.REAL, index);
-        return asJavaReal(subterm).orElseThrow(() -> newTermCastException(IStrategoTerm.REAL, term.getTermType(), index));
+        if (subterm == null) throw newTermNullException(TermType.REAL, index);
+        return asJavaReal(subterm).orElseThrow(() -> newTermCastException(TermType.REAL, term.getType(), index));
     }
 
     /**
@@ -921,8 +921,8 @@ public final class TermUtils {
     public static List<IStrategoTerm> toJavaListAt(IStrategoTerm term, int index) {
         if (term == null) throw newTermNullException();
         IStrategoTerm subterm = term.getSubterm(index);
-        if (subterm == null) throw newTermNullException(IStrategoTerm.LIST, index);
-        return asJavaList(subterm).orElseThrow(() -> newTermCastException(IStrategoTerm.LIST, term.getTermType(), index));
+        if (subterm == null) throw newTermNullException(TermType.LIST, index);
+        return asJavaList(subterm).orElseThrow(() -> newTermCastException(TermType.LIST, term.getType(), index));
     }
 
     // Speciality functions
@@ -963,7 +963,7 @@ public final class TermUtils {
      * @param actualType the actual term type
      * @return the {@link ClassCastException}
      */
-    private static ClassCastException newTermCastException(int expectedType, int actualType) {
+    private static ClassCastException newTermCastException(TermType expectedType, TermType actualType) {
         return newTermCastException(expectedType, actualType, -1);
     }
 
@@ -975,7 +975,7 @@ public final class TermUtils {
      * @param index the zero-based index of the subterm; or -1 when it is not a subterm
      * @return the {@link ClassCastException}
      */
-    private static ClassCastException newTermCastException(int expectedType, int actualType, int index) {
+    private static ClassCastException newTermCastException(TermType expectedType, TermType actualType, int index) {
         StringBuilder sb = new StringBuilder();
         sb.append("Expected ");
         sb.append(termTypeToString(expectedType));
@@ -1003,7 +1003,7 @@ public final class TermUtils {
      * @param expectedType the expected term type
      * @return the {@link NullPointerException}
      */
-    private static NullPointerException newTermNullException(int expectedType) {
+    private static NullPointerException newTermNullException(TermType expectedType) {
         return newTermNullException(expectedType, -1);
     }
 
@@ -1014,7 +1014,7 @@ public final class TermUtils {
      * @param index the zero-based index of the subterm; or -1 when it is not a subterm
      * @return the {@link NullPointerException}
      */
-    private static NullPointerException newTermNullException(int expectedType, int index) {
+    private static NullPointerException newTermNullException(TermType expectedType, int index) {
         StringBuilder sb = new StringBuilder();
         sb.append("Expected ");
         sb.append(termTypeToString(expectedType));
@@ -1032,7 +1032,7 @@ public final class TermUtils {
      * @param term the term that failed the assertion
      * @return the assertion message
      */
-    private static String getTypeMismatchAssertionMessage(Class<?> expectedClass, int expectedType, IStrategoTerm term) {
+    private static String getTypeMismatchAssertionMessage(Class<?> expectedClass, TermType expectedType, IStrategoTerm term) {
         return "Expected " +
                 termTypeToString(expectedType) +
                 " term to implement interface " +
@@ -1047,18 +1047,18 @@ public final class TermUtils {
      * @param type the type to convert
      * @return the string representation
      */
-    private static String termTypeToString(int type) {
+    private static String termTypeToString(TermType type) {
         switch(type) {
-            case IStrategoTerm.APPL: return "a Constructor Application";
-            case IStrategoTerm.LIST: return "a List";
-            case IStrategoTerm.INT: return "an Int";
-            case IStrategoTerm.REAL: return "a Real";
-            case IStrategoTerm.STRING: return "a String";
-            case IStrategoTerm.CTOR: return "a Constructor";
-            case IStrategoTerm.TUPLE: return "a Tuple";
-            case IStrategoTerm.REF: return "a Ref";
-            case IStrategoTerm.BLOB: return "a Blob";
-            case IStrategoTerm.PLACEHOLDER: return "a Placeholder";
+            case APPL: return "a Constructor Application";
+            case LIST: return "a List";
+            case INT: return "an Int";
+            case REAL: return "a Real";
+            case STRING: return "a String";
+            case CTOR: return "a Constructor";
+            case TUPLE: return "a Tuple";
+            case REF: return "a Ref";
+            case BLOB: return "a Blob";
+            case PLACEHOLDER: return "a Placeholder";
             default: return "an unrecognized";
         }
     }

--- a/org.spoofax.terms/src/org/spoofax/terms/visitor/StrategoTermVisitee.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/visitor/StrategoTermVisitee.java
@@ -4,15 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.Stack;
 
-import org.spoofax.interpreter.terms.IStrategoAppl;
-import org.spoofax.interpreter.terms.IStrategoInt;
-import org.spoofax.interpreter.terms.IStrategoList;
-import org.spoofax.interpreter.terms.IStrategoPlaceholder;
-import org.spoofax.interpreter.terms.IStrategoReal;
-import org.spoofax.interpreter.terms.IStrategoRef;
-import org.spoofax.interpreter.terms.IStrategoString;
-import org.spoofax.interpreter.terms.IStrategoTerm;
-import org.spoofax.interpreter.terms.IStrategoTuple;
+import org.spoofax.interpreter.terms.*;
 
 public class StrategoTermVisitee {
     public static void topdown(IStrategoTermVisitor visitor, IStrategoTerm initialTerm) {
@@ -49,26 +41,26 @@ public class StrategoTermVisitee {
     }
 
     private static boolean dispatch(IStrategoTermVisitor visitor, IStrategoTerm term) {
-        switch(term.getTermType()) {
-            case IStrategoTerm.APPL:
+        switch(term.getType()) {
+            case APPL:
                 return visitor.visit((IStrategoAppl) term);
-            case IStrategoTerm.LIST:
+            case LIST:
                 return visitor.visit((IStrategoList) term);
-            case IStrategoTerm.TUPLE:
+            case TUPLE:
                 return visitor.visit((IStrategoTuple) term);
-            case IStrategoTerm.INT:
+            case INT:
                 visitor.visit((IStrategoInt) term);
                 return false;
-            case IStrategoTerm.REAL:
+            case REAL:
                 visitor.visit((IStrategoReal) term);
                 return false;
-            case IStrategoTerm.STRING:
+            case STRING:
                 visitor.visit((IStrategoString) term);
                 return false;
-            case IStrategoTerm.REF:
+            case REF:
                 visitor.visit((IStrategoRef) term);
                 return false;
-            case IStrategoTerm.PLACEHOLDER:
+            case PLACEHOLDER:
                 return visitor.visit((IStrategoPlaceholder) term);
             default:
                 return visitor.visit(term);

--- a/org.spoofax.terms/src/org/spoofax/terms/visitor/StrategoTermVisitee.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/visitor/StrategoTermVisitee.java
@@ -4,7 +4,15 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.Stack;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoInt;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoPlaceholder;
+import org.spoofax.interpreter.terms.IStrategoReal;
+import org.spoofax.interpreter.terms.IStrategoRef;
+import org.spoofax.interpreter.terms.IStrategoString;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.IStrategoTuple;
 
 public class StrategoTermVisitee {
     public static void topdown(IStrategoTermVisitor visitor, IStrategoTerm initialTerm) {

--- a/org.spoofax.terms/test/org/spoofax/DummyStrategoConstructor.java
+++ b/org.spoofax.terms/test/org/spoofax/DummyStrategoConstructor.java
@@ -1,6 +1,10 @@
 package org.spoofax;
 
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoConstructor;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.ITermFactory;
 
 
 /**

--- a/org.spoofax.terms/test/org/spoofax/DummyStrategoTerm.java
+++ b/org.spoofax.terms/test/org/spoofax/DummyStrategoTerm.java
@@ -3,6 +3,7 @@ package org.spoofax;
 import org.spoofax.interpreter.terms.IStrategoList;
 import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermPrinter;
+import org.spoofax.interpreter.terms.TermType;
 import org.spoofax.terms.TermFactory;
 
 import java.io.IOException;
@@ -41,8 +42,14 @@ public class DummyStrategoTerm extends DummySimpleTerm implements IStrategoTerm 
     }
 
     @Override
+    @Deprecated
     public int getTermType() {
-        return 9;
+        return getType().getValue();
+    }
+
+    @Override
+    public TermType getType() {
+        return TermType.BLOB;
     }
 
     @Override

--- a/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoApplTests.java
+++ b/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoApplTests.java
@@ -102,10 +102,10 @@ public interface IStrategoApplTests {
 
 
     /**
-     * Tests the {@link IStrategoAppl#getTermType()} method.
+     * Tests the {@link IStrategoAppl#getType()} method.
      */
-    @DisplayName("getTermType()")
-    interface GetTermTypeTests extends Fixture, IStrategoTermTests.GetTermTypeTests {
+    @DisplayName("getType()")
+    interface GetTypeTests extends Fixture, IStrategoTermTests.GetTypeTests {
 
         @Test
         @DisplayName("returns the correct term type")
@@ -114,10 +114,10 @@ public interface IStrategoApplTests {
             IStrategoAppl sut = createIStrategoAppl(null, null, null, null);
 
             // Act
-            int result = sut.getTermType();
+            TermType result = sut.getType();
 
             // Assert
-            assertEquals(IStrategoTerm.APPL, result);
+            assertEquals(TermType.APPL, result);
         }
 
     }

--- a/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoConstructorTests.java
+++ b/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoConstructorTests.java
@@ -96,10 +96,10 @@ public interface IStrategoConstructorTests {
 
 
     /**
-     * Tests the {@link IStrategoConstructor#getTermType()} method.
+     * Tests the {@link IStrategoConstructor#getType()} method.
      */
-    @DisplayName("getTermType()")
-    interface GetTermTypeTests extends Fixture, IStrategoTermTests.GetTermTypeTests {
+    @DisplayName("getType()")
+    interface GetTypeTests extends Fixture, IStrategoTermTests.GetTypeTests {
 
         @Test
         @DisplayName("returns the correct term type")
@@ -108,10 +108,10 @@ public interface IStrategoConstructorTests {
             IStrategoConstructor sut = createIStrategoConstructor("Dummy", 2, null, null);
 
             // Act
-            int result = sut.getTermType();
+            TermType result = sut.getType();
 
             // Assert
-            assertEquals(IStrategoTerm.CTOR, result);
+            assertEquals(TermType.CTOR, result);
         }
 
     }

--- a/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoIntTests.java
+++ b/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoIntTests.java
@@ -70,10 +70,10 @@ public interface IStrategoIntTests {
 
 
     /**
-     * Tests the {@link IStrategoInt#getTermType()} method.
+     * Tests the {@link IStrategoInt#getType()} method.
      */
-    @DisplayName("getTermType()")
-    interface GetTermTypeTests extends Fixture, IStrategoTermTests.GetTermTypeTests {
+    @DisplayName("getType()")
+    interface GetTypeTests extends Fixture, IStrategoTermTests.GetTypeTests {
 
         @Test
         @DisplayName("returns the correct term type")
@@ -82,10 +82,10 @@ public interface IStrategoIntTests {
             IStrategoInt sut = createIStrategoInt(null, null, null);
 
             // Act
-            int result = sut.getTermType();
+            TermType result = sut.getType();
 
             // Assert
-            assertEquals(IStrategoTerm.INT, result);
+            assertEquals(TermType.INT, result);
         }
 
     }

--- a/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoListTests.java
+++ b/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoListTests.java
@@ -341,10 +341,10 @@ public interface IStrategoListTests {
 
 
     /**
-     * Tests the {@link IStrategoList#getTermType()} method.
+     * Tests the {@link IStrategoList#getType()} method.
      */
-    @DisplayName("getTermType()")
-    interface GetTermTypeTests extends Fixture, IStrategoTermTests.GetTermTypeTests {
+    @DisplayName("getType()")
+    interface GetTypeTests extends Fixture, IStrategoTermTests.GetTypeTests {
 
         @Test
         @DisplayName("empty list, returns the correct term type")
@@ -353,10 +353,10 @@ public interface IStrategoListTests {
             IStrategoList sut = createEmptyIStrategoList(null, null);
 
             // Act
-            int result = sut.getTermType();
+            TermType result = sut.getType();
 
             // Assert
-            assertEquals(IStrategoTerm.LIST, result);
+            assertEquals(TermType.LIST, result);
         }
 
         @Test
@@ -367,10 +367,10 @@ public interface IStrategoListTests {
             IStrategoList sut = createIStrategoList(elements, null, null);
 
             // Act
-            int result = sut.getTermType();
+            TermType result = sut.getType();
 
             // Assert
-            assertEquals(IStrategoTerm.LIST, result);
+            assertEquals(TermType.LIST, result);
         }
 
     }

--- a/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoPlaceholderTests.java
+++ b/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoPlaceholderTests.java
@@ -72,10 +72,10 @@ public interface IStrategoPlaceholderTests {
 
 
     /**
-     * Tests the {@link IStrategoPlaceholder#getTermType()} method.
+     * Tests the {@link IStrategoPlaceholder#getType()} method.
      */
-    @DisplayName("getTermType()")
-    interface GetTermTypeTests extends Fixture, IStrategoTermTests.GetTermTypeTests {
+    @DisplayName("getType()")
+    interface GetTypeTests extends Fixture, IStrategoTermTests.GetTypeTests {
 
         @Test
         @DisplayName("returns the correct term type")
@@ -84,10 +84,10 @@ public interface IStrategoPlaceholderTests {
             IStrategoPlaceholder sut = createIStrategoPlaceholder(null, null, null);
 
             // Act
-            int result = sut.getTermType();
+            TermType result = sut.getType();
 
             // Assert
-            assertEquals(IStrategoTerm.PLACEHOLDER, result);
+            assertEquals(TermType.PLACEHOLDER, result);
         }
 
     }

--- a/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoRealTests.java
+++ b/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoRealTests.java
@@ -70,10 +70,10 @@ public interface IStrategoRealTests {
 
 
     /**
-     * Tests the {@link IStrategoReal#getTermType()} method.
+     * Tests the {@link IStrategoReal#getType()} method.
      */
-    @DisplayName("getTermType()")
-    interface GetTermTypeTests extends Fixture, IStrategoTermTests.GetTermTypeTests {
+    @DisplayName("getType()")
+    interface GetTypeTests extends Fixture, IStrategoTermTests.GetTypeTests {
 
         @Test
         @DisplayName("returns the correct term type")
@@ -82,10 +82,10 @@ public interface IStrategoRealTests {
             IStrategoReal sut = createIStrategoReal(null, null, null);
 
             // Act
-            int result = sut.getTermType();
+            TermType result = sut.getType();
 
             // Assert
-            assertEquals(IStrategoTerm.REAL, result);
+            assertEquals(TermType.REAL, result);
         }
 
     }

--- a/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoStringTests.java
+++ b/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoStringTests.java
@@ -97,10 +97,10 @@ public interface IStrategoStringTests {
 
 
     /**
-     * Tests the {@link IStrategoString#getTermType()} method.
+     * Tests the {@link IStrategoString#getType()} method.
      */
-    @DisplayName("getTermType()")
-    interface GetTermTypeTests extends Fixture, IStrategoTermTests.GetTermTypeTests {
+    @DisplayName("getType()")
+    interface GetTypeTests extends Fixture, IStrategoTermTests.GetTypeTests {
 
         @Test
         @DisplayName("returns the correct term type")
@@ -109,10 +109,10 @@ public interface IStrategoStringTests {
             IStrategoString sut = createIStrategoString(null, null, null);
 
             // Act
-            int result = sut.getTermType();
+            TermType result = sut.getType();
 
             // Assert
-            assertEquals(IStrategoTerm.STRING, result);
+            assertEquals(TermType.STRING, result);
         }
 
     }

--- a/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoTermTests.java
+++ b/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoTermTests.java
@@ -296,10 +296,10 @@ public interface IStrategoTermTests {
 
 
     /**
-     * Tests the {@link IStrategoTerm#getTermType()} method.
+     * Tests the {@link IStrategoTerm#getType()} method.
      */
-    @DisplayName("getTermType()")
-    interface GetTermTypeTests extends Fixture {
+    @DisplayName("getType()")
+    interface GetTypeTests extends Fixture {
 
         @Test
         @DisplayName("returns a valid term type")
@@ -308,21 +308,21 @@ public interface IStrategoTermTests {
             IStrategoTerm sut = createIStrategoTerm(null, null, null);
 
             // Act
-            int result = sut.getTermType();
+            TermType result = sut.getType();
 
             // Assert
             assertTrue(
                 // @formatter:off
-                result == IStrategoTerm.APPL ||
-                result == IStrategoTerm.LIST ||
-                result == IStrategoTerm.INT ||
-                result == IStrategoTerm.REAL ||
-                result == IStrategoTerm.STRING ||
-                result == IStrategoTerm.CTOR ||
-                result == IStrategoTerm.TUPLE ||
-                result == IStrategoTerm.REF ||
-                result == IStrategoTerm.BLOB ||
-                result == IStrategoTerm.PLACEHOLDER
+                result == TermType.APPL ||
+                result == TermType.LIST ||
+                result == TermType.INT ||
+                result == TermType.REAL ||
+                result == TermType.STRING ||
+                result == TermType.CTOR ||
+                result == TermType.TUPLE ||
+                result == TermType.REF ||
+                result == TermType.BLOB ||
+                result == TermType.PLACEHOLDER
                 // @formatter:on
             );
         }

--- a/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoTupleTests.java
+++ b/org.spoofax.terms/test/org/spoofax/interpreter/terms/IStrategoTupleTests.java
@@ -146,10 +146,10 @@ public interface IStrategoTupleTests {
 
 
     /**
-     * Tests the {@link IStrategoTuple#getTermType()} method.
+     * Tests the {@link IStrategoTuple#getType()} method.
      */
-    @DisplayName("getTermType()")
-    interface GetTermTypeTests extends Fixture, IStrategoTermTests.GetTermTypeTests {
+    @DisplayName("getType()")
+    interface GetTypeTests extends Fixture, IStrategoTermTests.GetTypeTests {
 
         @Test
         @DisplayName("returns the correct term type")
@@ -158,10 +158,10 @@ public interface IStrategoTupleTests {
             IStrategoTuple sut = createIStrategoTuple(null, null, null);
 
             // Act
-            int result = sut.getTermType();
+            TermType result = sut.getType();
 
             // Assert
-            assertEquals(IStrategoTerm.TUPLE, result);
+            assertEquals(TermType.TUPLE, result);
         }
 
     }

--- a/org.spoofax.terms/test/org/spoofax/terms/StrategoApplTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/StrategoApplTests.java
@@ -88,7 +88,7 @@ public class StrategoApplTests {
     // IStrategoAppl
     @Nested class GetConstructorTests    extends FixtureImpl implements IStrategoApplTests.GetConstructorTests {}
     @Nested class GetNameTests           extends FixtureImpl implements IStrategoApplTests.GetNameTests {}
-    @Nested class GetTermTypeTests       extends FixtureImpl implements IStrategoApplTests.GetTermTypeTests {}
+    @Nested class GetTypeTests           extends FixtureImpl implements IStrategoApplTests.GetTypeTests {}
     @Nested class MatchTests             extends FixtureImpl implements IStrategoApplTests.MatchTests {}
     @Nested class ToStringTests          extends FixtureImpl implements IStrategoApplTests.ToStringTests {}
     @Nested class WriteAsStringTests     extends FixtureImpl implements IStrategoApplTests.WriteAsStringTests {}

--- a/org.spoofax.terms/test/org/spoofax/terms/StrategoArrayListTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/StrategoArrayListTests.java
@@ -123,7 +123,7 @@ public class StrategoArrayListTests {
 
     // @formatter:off
     // IStrategoList
-    @Nested class GetTermTypeTests       extends FixtureImpl implements IStrategoListTests.GetTermTypeTests {}
+    @Nested class GetTypeTests           extends FixtureImpl implements IStrategoListTests.GetTypeTests {}
     @Nested class HeadTests              extends FixtureImpl implements IStrategoListTests.HeadTests {}
     @Nested class IsEmptyTests           extends FixtureImpl implements IStrategoListTests.IsEmptyTests {}
     @Nested class MatchTests             extends FixtureImpl implements IStrategoListTests.MatchTests {}

--- a/org.spoofax.terms/test/org/spoofax/terms/StrategoConstructorTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/StrategoConstructorTests.java
@@ -4,7 +4,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.opentest4j.TestAbortedException;
 import org.spoofax.TestUtils;
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.ISimpleTermTests;
+import org.spoofax.interpreter.terms.IStrategoConstructorTests;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.IStrategoTermTests;
 import org.spoofax.terms.attachments.ITermAttachment;
 
 import javax.annotation.Nullable;

--- a/org.spoofax.terms/test/org/spoofax/terms/StrategoConstructorTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/StrategoConstructorTests.java
@@ -61,7 +61,7 @@ public class StrategoConstructorTests {
     @Nested class GetArityTests          extends FixtureImpl implements IStrategoConstructorTests.GetArityTests {}
     @Nested class GetNameTests           extends FixtureImpl implements IStrategoConstructorTests.GetNameTests {}
     @Nested class GetSubtermCountTests   extends FixtureImpl implements IStrategoConstructorTests.GetSubtermCountTests {}
-    @Nested class GetTermTypeTests       extends FixtureImpl implements IStrategoConstructorTests.GetTermTypeTests {}
+    @Nested class GetTypeTests           extends FixtureImpl implements IStrategoConstructorTests.GetTypeTests {}
     @Nested class MatchTests             extends FixtureImpl implements IStrategoConstructorTests.MatchTests {}
     @Nested class ToStringTests          extends FixtureImpl implements IStrategoConstructorTests.ToStringTests {}
     @Nested class WriteAsStringTests     extends FixtureImpl implements IStrategoConstructorTests.WriteAsStringTests {}

--- a/org.spoofax.terms/test/org/spoofax/terms/StrategoIntTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/StrategoIntTests.java
@@ -64,7 +64,7 @@ public class StrategoIntTests {
     @Nested class GetAllSubtermsTests    extends FixtureImpl implements IStrategoIntTests.GetAllSubtermsTests {}
     @Nested class GetSubtermsTests       extends FixtureImpl implements IStrategoIntTests.GetSubtermsTests {}
     @Nested class GetSubtermCountTests   extends FixtureImpl implements IStrategoIntTests.GetSubtermCountTests {}
-    @Nested class GetTermTypeTests       extends FixtureImpl implements IStrategoIntTests.GetTermTypeTests {}
+    @Nested class GetTypeTests           extends FixtureImpl implements IStrategoIntTests.GetTypeTests {}
     @Nested class IntValueTests          extends FixtureImpl implements IStrategoIntTests.IntValueTests {}
     @Nested class MatchTests             extends FixtureImpl implements IStrategoIntTests.MatchTests {}
     @Nested class ToStringTests          extends FixtureImpl implements IStrategoIntTests.ToStringTests {}

--- a/org.spoofax.terms/test/org/spoofax/terms/StrategoListTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/StrategoListTests.java
@@ -121,7 +121,7 @@ public class StrategoListTests {
 
     // @formatter:off
     // IStrategoList
-    @Nested class GetTermTypeTests       extends FixtureImpl implements IStrategoListTests.GetTermTypeTests {}
+    @Nested class GetTypeTests           extends FixtureImpl implements IStrategoListTests.GetTypeTests {}
     @Nested class HeadTests              extends FixtureImpl implements IStrategoListTests.HeadTests {}
     @Nested class IsEmptyTests           extends FixtureImpl implements IStrategoListTests.IsEmptyTests {}
     @Nested class MatchTests             extends FixtureImpl implements IStrategoListTests.MatchTests {}

--- a/org.spoofax.terms/test/org/spoofax/terms/StrategoPlaceholderTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/StrategoPlaceholderTests.java
@@ -60,7 +60,7 @@ public class StrategoPlaceholderTests {
     @Nested class GetSubtermsTests       extends FixtureImpl implements IStrategoPlaceholderTests.GetSubtermsTests {}
     @Nested class GetSubtermCountTests   extends FixtureImpl implements IStrategoPlaceholderTests.GetSubtermCountTests {}
     @Nested class GetTemplateTests       extends FixtureImpl implements IStrategoPlaceholderTests.GetTemplateTests {}
-    @Nested class GetTermTypeTests       extends FixtureImpl implements IStrategoPlaceholderTests.GetTermTypeTests {}
+    @Nested class GetTypeTests           extends FixtureImpl implements IStrategoPlaceholderTests.GetTypeTests {}
     @Nested class MatchTests             extends FixtureImpl implements IStrategoPlaceholderTests.MatchTests {}
     @Nested class ToStringTests          extends FixtureImpl implements IStrategoPlaceholderTests.ToStringTests {}
     @Nested class WriteAsStringTests     extends FixtureImpl implements IStrategoPlaceholderTests.WriteAsStringTests {}

--- a/org.spoofax.terms/test/org/spoofax/terms/StrategoRealTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/StrategoRealTests.java
@@ -4,7 +4,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.opentest4j.TestAbortedException;
 import org.spoofax.TestUtils;
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.ISimpleTermTests;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoRealTests;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.IStrategoTermTests;
 import org.spoofax.terms.attachments.ITermAttachment;
 
 import javax.annotation.Nullable;

--- a/org.spoofax.terms/test/org/spoofax/terms/StrategoRealTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/StrategoRealTests.java
@@ -59,7 +59,7 @@ public class StrategoRealTests {
     @Nested class GetAllSubtermsTests    extends FixtureImpl implements IStrategoRealTests.GetAllSubtermsTests {}
     @Nested class GetSubtermsTests       extends FixtureImpl implements IStrategoRealTests.GetSubtermsTests {}
     @Nested class GetSubtermCountTests   extends FixtureImpl implements IStrategoRealTests.GetSubtermCountTests {}
-    @Nested class GetTermTypeTests       extends FixtureImpl implements IStrategoRealTests.GetTermTypeTests {}
+    @Nested class GetTypeTests           extends FixtureImpl implements IStrategoRealTests.GetTypeTests {}
     @Nested class RealValueTests         extends FixtureImpl implements IStrategoRealTests.RealValueTests {}
     @Nested class MatchTests             extends FixtureImpl implements IStrategoRealTests.MatchTests {}
     @Nested class ToStringTests          extends FixtureImpl implements IStrategoRealTests.ToStringTests {}

--- a/org.spoofax.terms/test/org/spoofax/terms/StrategoStringTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/StrategoStringTests.java
@@ -65,7 +65,7 @@ public class StrategoStringTests {
     @Nested class GetSubtermsTests       extends FixtureImpl implements IStrategoStringTests.GetSubtermsTests {}
     @Nested class GetNameTests           extends FixtureImpl implements IStrategoStringTests.GetNameTests {}
     @Nested class GetSubtermCountTests   extends FixtureImpl implements IStrategoStringTests.GetSubtermCountTests {}
-    @Nested class GetTermTypeTests       extends FixtureImpl implements IStrategoStringTests.GetTermTypeTests {}
+    @Nested class GetTypeTests           extends FixtureImpl implements IStrategoStringTests.GetTypeTests {}
     @Nested class StringValueTests       extends FixtureImpl implements IStrategoStringTests.StringValueTests {}
     @Nested class MatchTests             extends FixtureImpl implements IStrategoStringTests.MatchTests {}
     @Nested class ToStringTests          extends FixtureImpl implements IStrategoStringTests.ToStringTests {}

--- a/org.spoofax.terms/test/org/spoofax/terms/StrategoTupleTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/StrategoTupleTests.java
@@ -62,7 +62,7 @@ public class StrategoTupleTests {
 
     // @formatter:off
     // IStrategoTuple
-    @Nested class GetTermTypeTests       extends FixtureImpl implements IStrategoTupleTests.GetTermTypeTests {}
+    @Nested class GetTypeTests           extends FixtureImpl implements IStrategoTupleTests.GetTypeTests {}
     @Nested class GetTests               extends FixtureImpl implements IStrategoTupleTests.GetTests {}
     @Nested class MatchTests             extends FixtureImpl implements IStrategoTupleTests.MatchTests {}
     @Nested class SizeTests              extends FixtureImpl implements IStrategoTupleTests.SizeTests {}

--- a/org.spoofax.terms/test/org/spoofax/terms/io/SimpleTextTermWriterTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/io/SimpleTextTermWriterTests.java
@@ -1,8 +1,20 @@
 package org.spoofax.terms.io;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
 import org.spoofax.DummyTermAttachment;
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoInt;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoPlaceholder;
+import org.spoofax.interpreter.terms.IStrategoReal;
+import org.spoofax.interpreter.terms.IStrategoString;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.IStrategoTuple;
+import org.spoofax.interpreter.terms.ITermFactory;
 import org.spoofax.terms.TermFactory;
 import org.spoofax.terms.attachments.ITermAttachment;
 

--- a/org.spoofax.terms/test/org/spoofax/terms/io/binary/SAFReaderTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/io/binary/SAFReaderTests.java
@@ -5,7 +5,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -20,10 +19,8 @@ import org.spoofax.interpreter.terms.IStrategoTerm;
 import org.spoofax.interpreter.terms.ITermFactory;
 import org.spoofax.terms.TermFactory;
 import org.spoofax.terms.io.AbstractTermReaderTests;
-import org.spoofax.terms.io.TAFTermReader;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /** Tests the {@link SAFReader} class. */
 @DisplayName("SAFReader")

--- a/org.spoofax.terms/test/org/spoofax/terms/util/TermUtilsTests.java
+++ b/org.spoofax.terms/test/org/spoofax/terms/util/TermUtilsTests.java
@@ -3,7 +3,13 @@ package org.spoofax.terms.util;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.spoofax.interpreter.terms.*;
+import org.spoofax.interpreter.terms.IStrategoAppl;
+import org.spoofax.interpreter.terms.IStrategoInt;
+import org.spoofax.interpreter.terms.IStrategoList;
+import org.spoofax.interpreter.terms.IStrategoReal;
+import org.spoofax.interpreter.terms.IStrategoString;
+import org.spoofax.interpreter.terms.IStrategoTerm;
+import org.spoofax.interpreter.terms.IStrategoTuple;
 import org.spoofax.terms.StrategoConstructor;
 import org.spoofax.terms.TermFactory;
 


### PR DESCRIPTION
This PR:

- adds the `TermType` enum, which allows exhaustive term type matching;
- adds `IStrategoTerm.getType()`, which returns a member of the `TermType` enum;
- deprecates `IStrategoTerm.getTermType()`, as it returns an integer value (remnant of C-style 'enums');
- deprecates the `IStrategoTerm` `APPL`, `LIST`, `INT`, `REAL`, `STRING`, `CTOR`, `TUPLE`, `REF`, `BLOB` and `PLACEHOLDER` integer constants;
- replaces many uses of `getTermType()` with `getType()`.

This PR allows you to write `switch` on `IStrategoTerm.getType()` without having to prefix every case with `IStrategoTerm`, or having to do a static import for each member. In languages that support it (e.g., Kotlin), the compiler can detect that the switch-case is exhaustive. As enums are safely compared using reference equality, this PR will have no performance impact (comparing two pointers is the same as comparing two integers).

Related:
- metaborg/mb-exec#9
- metaborg/nabl#33
- metaborg/flowspec#5
- metaborg/jsglr#82
- metaborg/strategoxt#33