### PR TITLE
Only intern strings ending with a number like `new` and `newname` generate, so we intern many fewer strings

### DIFF
--- a/org.spoofax.terms/src/org/spoofax/terms/TermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/TermFactory.java
@@ -70,7 +70,7 @@ public class TermFactory extends AbstractTermFactory implements ITermFactory {
     }
 
     @Override public IStrategoString makeString(String s) {
-        if(s.length() <= MAX_POOLED_STRING_LENGTH && endsWithNumber(s)) {
+        if(s.length() <= MAX_POOLED_STRING_LENGTH && endsWithDigit(s)) {
             synchronized(usedStrings) {
                 s = usedStrings.intern(s);
             }
@@ -78,7 +78,7 @@ public class TermFactory extends AbstractTermFactory implements ITermFactory {
         return new StrategoString(s, null);
     }
 
-    protected static boolean endsWithNumber(String s) {
+    public static final boolean endsWithDigit(String s) {
         if(s.isEmpty()) {
             return false;
         }

--- a/org.spoofax.terms/src/org/spoofax/terms/TermFactory.java
+++ b/org.spoofax.terms/src/org/spoofax/terms/TermFactory.java
@@ -70,12 +70,20 @@ public class TermFactory extends AbstractTermFactory implements ITermFactory {
     }
 
     @Override public IStrategoString makeString(String s) {
-        if(s.length() <= MAX_POOLED_STRING_LENGTH) {
+        if(s.length() <= MAX_POOLED_STRING_LENGTH && endsWithNumber(s)) {
             synchronized(usedStrings) {
                 s = usedStrings.intern(s);
             }
         }
         return new StrategoString(s, null);
+    }
+
+    protected static boolean endsWithNumber(String s) {
+        if(s.isEmpty()) {
+            return false;
+        }
+        char lastChar = s.charAt(s.length() - 1);
+        return '0' <= lastChar && lastChar <= '9';
     }
 
     @Override public IStrategoString tryMakeUniqueString(String s) {


### PR DESCRIPTION
Suggestion made by @virtlink

Waiting for a local build to see if all the tests still work. Then this will be merged.